### PR TITLE
addresses bundle install failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     minitest (5.10.2)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.7.2)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.1.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       typhoeus (~> 0.7)
     html-pipeline (2.5.0)
       activesupport (>= 2)
-      nokogiri (>= 1.4)
+      nokogiri (>= 1.8.2)
     i18n (0.8.1)
     jekyll (3.4.3)
       addressable (~> 2.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
+    concurrent-ruby (1.0.5)
     ethon (0.10.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -69,10 +70,11 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 2.0)
       typhoeus (~> 0.7)
-    html-pipeline (2.5.0)
+    html-pipeline (2.7.1)
       activesupport (>= 2)
-      nokogiri (>= 1.8.2)
-    i18n (0.8.1)
+      nokogiri (>= 1.4)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     jekyll (3.4.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -158,14 +160,14 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
-    minitest (5.10.2)
+    minitest (5.11.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
     nokogiri (1.8.2)
-      mini_portile2 (~> 2.1.0)
+      mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.14.0)
@@ -185,7 +187,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.2.1)
 
@@ -194,7 +196,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  minima
 
 BUNDLED WITH
-   1.15.0
+   1.16.1


### PR DESCRIPTION
PR #16 was merged into master instead of the gh-pages branch. Let me know if I'm wrong but I don't expect that to result in any problems. Creating this PR to merge into the proper branch.

---

After merging #15, we saw a similar error about the html-pipeline package. I ran bundle update html-pipeline which resulted in the following changes. Based on my testing, I would expect this to resolve our build failures.

**Error from Jenkins job output:**

```
Fetching nokogiri 1.8.2
Installing nokogiri 1.8.2 with native extensions
Fetching html-pipeline 2.5.0
Downloading html-pipeline-2.5.0 revealed dependencies not in the API or the lockfile (nokogiri (>= 1.4)).
Either installing with `--full-index` or running `bundle update html-pipeline` should fix the problem.

In Gemfile:
  github-pages was resolved to 138, which depends on
    jekyll-mentions was resolved to 1.2.0, which depends on
      html-pipeline
```