### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,8 +1,12 @@
 ![CCADB](images/big-logo.png){:width="200px" style="float: right" }
 
 The Common CA Database (CCADB) is a repository of information about
-Certificate Authorities (CAs), and their root and intermediate certificates
-that are used in the WebPKI - the publicly-trusted system which underpins
-secure connections on the Web. The CCADB is used by a number of different
+externally operated Certificate Authorities (CAs) whose root and
+intermediate certificates are included within 
+the products and services of CCADB root store members.
+Root store operators participate in the CCADB to improve security,
+transparency, and interoperability.
+The CCADB is used by a number of different
 root store operators to manage their root stores, but it is run by
 [Mozilla](https://www.mozilla.org/mission/).
+


### PR DESCRIPTION
Replace text that was webPKI-centric, because the root store members of the CCADB include certificates used for other purposes as well.