### PR TITLE
Cleanup feb22

### DIFF
--- a/cas/ALV.md
+++ b/cas/ALV.md
@@ -9,7 +9,7 @@ Table of Contents:
 
 ## Root Certificates ##
 
-CAs are required to update the audit, CP, CPS and test website information for their certificate hierarchies at least annually. To provide this information for root certificates, create one [Audit Case](updates#audit-case-workflow) in the CCADB for a particular set of audits (e.g. Standard Audit, BR audit, EV SSL Audit, Code Signing Audit).
+CAs are required to update the audit, CP, CPS and test website information for their certificate hierarchies at least annually. To provide this information for root certificates, create one [Add/Update Root Request Case](updates#audit-case-workflow) in the CCADB for a particular set of audits (e.g. Standard Audit, BR audit, EV SSL Audit, Code Signing Audit).
 * [Update audit, CP, CPS, and testwebsite information in the CCADB ](updates)
 
 ## Intermediate Certificates ##

--- a/cas/ALV.md
+++ b/cas/ALV.md
@@ -41,7 +41,7 @@ When ALV returns FAIL for "Standard Audit ALV Found Cert", "Code Signing Audit A
 * If the SHA-256 fingerprint is listed in the audit statement, then make sure that it meets the [format specifications](../policy#51-audit-statement-content), such as no colons, no spaces, no line feeds.
 * Have your auditor provide an updated audit statement that follows the [formatting requirements](../policy#51-audit-statement-content) for the SHA-256 Fingerprints.
 * If you do not agree with the ALV results, add comments to the "Standard Audit ALV Comments", "Code Signing Audit ALV Comments", "BR Audit ALV Comments", or "EV SSL Audit ALV Comments" fields to indicate that the SHA-256 fingerprint is listed correctly in the audit statement.
-* If the audit statement is indeed missing the SHA-256 fingerprint for the certificate, then file an [Incident Report](https://wiki.mozilla.org/CA/Incident_Dashboard), and add the link to the Incident Report to one of the "...ALV Comments" fields.
+* If the audit statement is indeed missing the SHA-256 fingerprint for the certificate, then file an [Incident Report](https://www.ccadb.org/cas/incident-report), and add the link to the Incident Report to one of the "...ALV Comments" fields.
 
 Important clarifications:
 
@@ -54,10 +54,10 @@ Important clarifications:
 
 Acceptable remediation:
 * Have your auditor issue a revised report that includes the intermediate certificate.
-    * If the certificate has been in existence for past audit periods, then you must also file an [Incident Report](https://wiki.mozilla.org/CA/Incident_Dashboard).
+    * If the certificate has been in existence for past audit periods, then you must also file an [Incident Report](https://www.ccadb.org/cas/incident-report).
     * An Incident Report may not be needed if the certificate is self-signed and has the same Subject + SPKI as other certificates listed in the audit statement. For example, this can happen when a Root Store includes one version of a root certificate, but another version of the root certificate can be part of a valid chain constructed as: leaf --> untrusted root --> trusted root.
 * Revoke the intermediate certificate in accordance with Root Store policies and the BRs.
-    * If your CA decides not to revoke the certificate within the timeline specified by section 4.9 of the BRs, then that is another incident, which must be addressed in a separate [Incident Report](https://wiki.mozilla.org/CA/Incident_Dashboard). 
+    * If your CA decides not to revoke the certificate within the timeline specified by section 4.9 of the BRs, then that is another incident, which must be addressed in a separate [Incident Report](https://www.ccadb.org/cas/incident-report). 
 
 ## Common ALV Findings ##
 ALV formatting requirements are specified in 

--- a/cas/ALV.md
+++ b/cas/ALV.md
@@ -1,6 +1,6 @@
 # Audit Letter Validation (ALV) #
 
-The CCADB uses an Audit Letter Validation (ALV) tool that is provided by Microsoft to automatically parse and validate audit statements. The ALV eliminates manual processing, but it requires audit statements to follow some basic rules in order to function properly. If an audit statement fails to meet any of the [Audit Statement Requirements and Format Rules](../policy#51-audit-statement-content), the CA will be asked to work with their auditor to provide an audit statement that passes ALV.
+The CCADB uses an Audit Letter Validation (ALV) tool that is provided by Microsoft to automatically parse and validate audit statements. The ALV eliminates manual processing, but it requires audit statements to follow some basic rules in order to function properly. If an audit statement fails to meet any of the [Audit Statement Requirements and Format Rules](../policy#51-audit-statement-content), the CA Owner will be asked to work with their auditor to provide an audit statement that passes ALV.
 
 Table of Contents:
 1. [Root Certificates](ALV#root-certificates)
@@ -9,23 +9,25 @@ Table of Contents:
 
 ## Root Certificates ##
 
-CAs are required to update the audit, CP, CPS and test website information for their certificate hierarchies at least annually. To provide this information for root certificates, create one [Add/Update Root Request Case](updates#audit-case-workflow) in the CCADB for a particular set of audits (e.g. Standard Audit, BR audit, EV SSL Audit, Code Signing Audit).
+CA Owners are required to update the audit, CP, CPS and test website information for their certificate hierarchies at least annually. To provide this information for root certificates, create one [Add/Update Root Request Case](updates#audit-case-workflow) in the CCADB for a particular set of audits (e.g. Standard Audit, BR audit, EV SSL Audit, Code Signing Audit).
 * [Update audit, CP, CPS, and testwebsite information in the CCADB ](updates)
 
 ## Intermediate Certificates ##
 
-Subordinate CAs who operate non-technically-constrained intermediate certificates have the keys to the internet just as much as the CAs who have root certificates directly included in a browser root store. Meaning that such subordinate CAs can also issue TLS certificates for any website or domain, so it is imperative that the same rules are being followed by all subordinate CAs operating non-technically-constrained intermediate certificates. There are currently about 150 root certificates in browser root stores, which leads to about 3,000 intermediate certificates that are trusted by browser root stores. 
+Subordinate CA Owners who operate non-technically-constrained intermediate certificates have the keys to the internet just as much as the CAs who have root certificates directly included in a Root Store. Meaning that such subordinate CA Owners can also issue TLS certificates for any website or domain, so it is imperative that the same rules are being followed by all subordinate CA Owners operating non-technically-constrained intermediate certificates. There are currently about 150 root certificates in the Root Stores of CCADB Root Store Operators, which leads to about 3,000 intermediate certificates that are trusted.
 
-To help enforce the rules at the intermediate certificate level, CCADB participants require [disclosure of intermediate certificates](/policy#4-intermediate-certificates). CCADB automatically runs ALV on the intermediate certificate records and reports the results to CAs and root store operators in their CCADB home pages.
+Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
-CAs are required to annually update the audit and CP/CPS for their non-technically-constrained intermediate certificates chaining to root certificates included in browser root stores. To provide this information for intermediate certificates, directly [update the corresponding record](intermediates#updating-audit-statements) in the CCADB then click on the "Audit Letter Validation [ALV]" button. 
+To help enforce the rules at the intermediate certificate level, some CCADB Root Store Operators require [disclosure of intermediate certificates](/policy#4-intermediate-certificates). CCADB automatically runs ALV on the intermediate certificate records and reports the results to CA Owners and Root Store Operators in their CCADB home pages.
+
+CA Owners are required to annually update the audit and CP/CPS for their non-technically-constrained intermediate certificates chaining to root certificates included in a Root Store. To provide this information for intermediate certificates, directly [update the corresponding record](intermediates#updating-audit-statements) in the CCADB then click on the "Audit Letter Validation [ALV]" button. 
 
 When the audit statements for an intermediate certificate are the same as the certificate that signed it, check the “Audits Same as Parent” checkbox instead of providing separate audit information. When the "Audits Same as Parent" field is checked for an intermediate certificate record, the CCADB will look up the parent chain until audit statements are found, and then run ALV using those audit statements. When the "Audits Same as Parent" field is not checked, the CCADB will directly pass the audit statements in the intermediate certificate record into ALV.
 
-The following fields are set by running ALV on an intermediate certificate record in the CCADB. CAs may cause ALV to be run on the record by clicking on the "Audit Letter Validation [ALV]" button. Additionally CCADB has automated processes that will regularly check for intermediate certificate records that need to have ALV run.
+The following fields are set by running ALV on an intermediate certificate record in the CCADB. CA Owners may cause ALV to be run on the record by clicking on the "Audit Letter Validation [ALV]" button. Additionally CCADB has automated processes that will regularly check for intermediate certificate records that need to have ALV run.
 
 * Standard Audit ALV Found Cert
-    * This field will be set to PASS when ALV finds the SHA-256 Fingerprint for that certificate in the standard audit statement
+    * This field will be set to PASS when ALV finds the SHA-256 Fingerprint for that certificate in the standard audit statement.
 * BR Audit ALV Found Cert
     * This field will only be set when the [Derived Trust Bits](fields#formula-fields) field has "Server Authentication" in its list. 
     * This field will be set to PASS when ALV finds the SHA-256 Fingerprint for that certificate in the BR audit statement. 
@@ -43,18 +45,18 @@ When ALV returns FAIL for "Standard Audit ALV Found Cert", "Code Signing Audit A
 
 Important clarifications:
 
-* If the CA has a currently valid audit report at the time of creation of the intermediate certificate, then the current audit statement does not need to be updated and the new certificate must appear on the CA's next periodic audit reports.
-* Intermediate certificates that contain "Server Authentication" in the [Derived Trust Bits](fields#formula-fields) field are considered to be technically capable of issuing TLS certificates, and they must be listed in the CA’s BR audit report.
+* If the CA Owner has a currently valid audit report at the time of creation of the intermediate certificate, then the current audit statement does not need to be updated and the new certificate must appear on the CA Owner's next periodic audit reports.
+* Intermediate certificates that contain "Server Authentication" in the [Derived Trust Bits](fields#formula-fields) field are considered to be technically capable of issuing TLS certificates, and they must be listed in the CA Owner’s BR audit report.
 * If multiple intermediate certificates with the same Subject + SPKI have been issued, each one must have their SHA-256 Fingerprint listed in appropriate audit statements according to the [Derived Trust Bits](fields#formula-fields) field.
 * Cross-Certificates are also considered intermediate certificates, which must also be audited and specifically listed in the applicable audit statements according to the [Derived Trust Bits](fields#formula-fields) field.
-* Self-signed certificates that share a Subject and SPKI with a root certificate that is included in a root store are treated by browsers as intermediate certificates because they chain up to an included root, so these certificates must also be listed in the applicable audit statements according to the [Derived Trust Bits](fields#formula-fields) field. 
-    * An example of this situation is when an older version of a root certificate exists and a newer version of the root certificate is created. In this case, a valid chain may be constructed as: leaf --> untrusted root --> trusted root. In other words, that "untrusted" root is technically trusted by the root store because it chains to a trusted root, so it's SHA256 fingerprint must also be listed in the applicable audit statements.
+* Self-signed certificates that share a Subject + SPKI with a root certificate that is included in a Root Store are treated by Root Store Operators as intermediate certificates because they chain up to an included root, so these certificates must also be listed in the applicable audit statements according to the [Derived Trust Bits](fields#formula-fields) field. 
+    * An example of this situation is when an older version of a root certificate exists and a newer version of the root certificate is created. In this case, a valid chain may be constructed as: leaf --> untrusted root --> trusted root. In other words, that "untrusted" root is technically trusted by the Root Store Operator because it chains to a trusted root, so it's SHA256 fingerprint must also be listed in the applicable audit statements.
 
 Acceptable remediation:
 * Have your auditor issue a revised report that includes the intermediate certificate.
     * If the certificate has been in existence for past audit periods, then you must also file an [Incident Report](https://wiki.mozilla.org/CA/Incident_Dashboard).
-    * An Incident Report may not be needed if the certificate is self-signed and has the same Subject and SPKI as other certificates listed in the audit statement. For example, this can happen when a root store includes one version of a root certificate, but another version of the root certificate can be part of a valid chain constructed as: leaf --> untrusted root --> trusted root.
-* Revoke the intermediate certificate in accordance with root store policies and the BRs.
+    * An Incident Report may not be needed if the certificate is self-signed and has the same Subject + SPKI as other certificates listed in the audit statement. For example, this can happen when a Root Store includes one version of a root certificate, but another version of the root certificate can be part of a valid chain constructed as: leaf --> untrusted root --> trusted root.
+* Revoke the intermediate certificate in accordance with Root Store policies and the BRs.
     * If your CA decides not to revoke the certificate within the timeline specified by section 4.9 of the BRs, then that is another incident, which must be addressed in a separate [Incident Report](https://wiki.mozilla.org/CA/Incident_Dashboard). 
 
 ## Common ALV Findings ##
@@ -101,7 +103,7 @@ ALV formatting requirements are specified in
 <td>Failed to validate EKU ... because the standard names and standard policies are not found in the audit letters </td>
 <td>ALV was unable to find the specific text (case insensitive) that it looks for for each EKU. For example, "319 411-1 v1.1.1, dvcp;ovcp;ptc-br" </td>
 <td>Make sure that the audit statement correctly indicates the audit criteria that was used, and that it satisfies root store requirements.
-The following are xamples of the policy information that ALV looks for, depending on the EKU's or Trust Bits that each root store has applied to the root certifiate, and the "Derived Trust Bits" for an intermediate certificate.
+The following are examples of the policy information that ALV looks for, depending on the EKU's or Trust Bits that each root store has applied to the root certifiate, and the "Derived Trust Bits" for an intermediate certificate.
 <ul>
 <li> ETSI EN 319 411-1 V1.2.2, LCP;DVCP </li>
 <li> ETSI EN 319 411-1 V1.2.2, LCP;OVCP;EVCP </li>
@@ -118,7 +120,7 @@ The following are xamples of the policy information that ALV looks for, dependin
 </tr>
 <tr valign="top">
 <td>Auditor Not Found </td>
-<td>ALV was unable to find the specified auditor name in the audit statement </td>
+<td>ALV was unable to find the specified auditor name in the audit statement. </td>
 <td>
 <ul>
 <li> Ensure the correct Auditor is selected in the record and that it matches the auditor name recorded in your audit statement. </li> 
@@ -128,7 +130,7 @@ The following are xamples of the policy information that ALV looks for, dependin
 </tr>
 <tr valign="top">
 <td>CA Owner Not Found </td>
-<td>ALV was unable to find the CA Owner's name (as specified in the CCADB) in the audit statement. For intermediate certificate records with their own audit statements this will be the value in the "Subordinate CA Owner" field </td>
+<td>ALV was unable to find the CA Owner's name (as specified in the CCADB) in the audit statement. For intermediate certificate records with their own audit statements this will be the value in the "Subordinate CA Owner" field. </td>
 <td>
 <ul>
 <li> Check that your CA Name in the CCADB is correct and that your CA Name specified in the Audit Letter is correct. </li>
@@ -150,8 +152,8 @@ The following are xamples of the policy information that ALV looks for, dependin
 <li> If you are testing the preliminary audit statement, then you may ignore this error. </li>
 <li> Make sure that the URL that you entered into the CCADB is https. </li>
 <li> If you are running ALV on the final audit statement, then this error should not happen unless the audit statement is qualified (WebTrust) or the ETSI Certificate was not issued. </li>
-<li> In those situations the root store operator will need to contact the auditor, so it will help if you provide the auditor's contact information in a Case Comment. </li>
-<li> If the audit statement is on the auditor's website and you are still receiving this error, then ask a root store manager to add the auditor's website to the list of known audit locations for ALV. </li>
+<li> In those situations the Root Store Operator will need to contact the auditor, so it will help if you provide the auditor's contact information in a Case Comment. </li>
+<li> If the audit statement is on the auditor's website and you are still receiving this error, then ask a Root Store Operator to add the auditor's website to the list of known audit locations for ALV. </li>
 </ul>
 </td> 
 </tr>

--- a/cas/fields.md
+++ b/cas/fields.md
@@ -36,14 +36,14 @@ There are 5 audit statements that may be provided:
 </ol>
 For each applicable audit, the following information must be provided, and must meet 
 the root store requirements and the requirements of 
-[section 5.1 of the Common CCADB Policy][CCADB-Policy].
+[section 5.1 of the CCADB Policy][CCADB-Policy].
 <table border="1">
 <tr valign="top"><th>Field Name</th><th>What to Enter</th></tr>
 
 <tr valign="top">
 <td>Audit</td>
 <td>URL to the audit statement PDF. <br>
-WebTrust Seals: Enter the WebTrust Seal URL into this field. When you save your changes, the CCADB will automatically convert the Seal URL to  the URL of the corresponding audit statement PDF.
+WebTrust Seals: Enter the WebTrust Seal URL into this field. When you save your changes, the CCADB will automatically convert the Seal URL to the URL of the corresponding audit statement PDF.
 </td>
 </tr>
 <tr valign="top">
@@ -237,7 +237,7 @@ certificate.</td>
 <tr valign="top"><th>Field Name</th><th>What to Enter</th></tr>
 <tr valign="top">
 <td>Revocation Status </td>
-<td> The Common CCADB Policy, says “If an intermediate certificate is revoked, the CCADB must be updated to mark it as revoked, giving the reason why, within 24 hours for a security incident, and within 7 days for any other reason.” 
+<td> The CCADB Policy, says “If a subordinate CA certificate is revoked, the CCADB must be updated to mark it as revoked, including the reason for revocation, within seven calendar days of revocation.” 
 </td>
 </tr>
 <tr valign="top">

--- a/cas/fields.md
+++ b/cas/fields.md
@@ -35,7 +35,7 @@ There are 5 audit statements that may be provided:
 <li>EV Code Signing Audit</li>
 </ol>
 For each applicable audit, the following information must be provided, and must meet 
-the root store requirements and the requirements of 
+the individual Root Store requirements and the requirements of 
 [section 5.1 of the CCADB Policy][CCADB-Policy].
 <table border="1">
 <tr valign="top"><th>Field Name</th><th>What to Enter</th></tr>
@@ -61,10 +61,10 @@ e.g. WebTrust or ETSI EN 319 411.
 Audit Period End Date</td>
 <td>In a period‐of‐time audit, the Audit Period is the period
 between the first day (start) and the last day of operations (end) covered by
-the auditors in their engagement.  (This is not the same as the period of time 
+the auditors in their engagement. (This is not the same as the period of time 
 when the auditors are on-site at the CA.)
 <br>
-The period during which the CA issues Certificates SHALL be divided into an
+The period during which the CA issues certificates SHALL be divided into an
 unbroken sequence of audit periods. An audit period MUST NOT exceed one year
 in duration.
 </td>
@@ -82,8 +82,8 @@ in duration.
 <tr valign="top">
 <td>Auditor </td>
 <td> Find all Auditors known to the CCADB by clicking on the 'Auditors' report
-in the 'Custom Links' section in any Root Certificate, Intermediate Certiifcate, 
-or Case page. Contact your root store operator if your auditor is not in this list. 
+in the 'Custom Links' section in any root certificate, intermediate certiifcate, 
+or case page. Contact your Root Store Operator if your auditor is not in this list. 
 <br>
 To fill in the auditor's name, click on the pencil icon in the 'Auditor' field, 
 then enter a string of two or more characters that you expect to be in your 
@@ -94,8 +94,8 @@ click on the 'Save' button.
 <tr valign="top">
 <td>Auditor Location </td>
 <td> Find all Auditor Locations known to the CCADB by clicking on the 'Auditors' report
-in the 'Custom Links' section in any Root Certificate, Intermediate Certiifcate, 
-or Case page. Contact your root store operator if your auditor's location is not in this list. 
+in the 'Custom Links' section in any root certificate, intermediate certiifcate, 
+or case page. Contact your Root Store Operator if your auditor's location is not in this list. 
 <br>
 To fill in the auditor's location, click on the pencil icon in the 'Auditor Location' field,
 then enter a string of two or more characters that you expect to be in your 
@@ -106,10 +106,11 @@ click on the 'Save' button.
 </table>
 
 <br>
-Auditor qualifications are verified and entered into the CCADB by a root store operator. 
+Auditor qualifications are verified and entered into the CCADB by a Root Store Operator. 
 For example, Mozilla re-verifies auditor qualifications annually as described
  [here][Auditor-Qualifications].
-
+ 
+ Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
 ## Formula Fields ##
 These are some of the fields that are automatically filled in by the CCADB and cannot be manually edited.
@@ -252,7 +253,7 @@ certificate.</td>
 </tr>
 <tr valign="top">
 <td>Alternate CRL</td>
-<td> Only fill in this field when this certificate does not contain a CRL URL. Note that the BRs now require intermediate certificates to contain CRL URLs.
+<td> Only fill in this field when this certificate does not contain a CRL URL. Note that the BRs require intermediate certificates to contain CRL URLs.
  </td>
 </tr>
 </table>
@@ -285,7 +286,7 @@ Example:
 ## Uploading Documents ##
 
 Many CCADB fields require URLs to documents. In general, CP/CPS and Audit
-information should be provided on the CA's website, subordinate CA's website, or the auditor's website.
+information should be provided on the CA Owner's website, subordinate CA Owner's website, or the auditor's website.
 However, if for some reason this is not possible, you can use the
 Bugzilla bug-tracking system to store the documents and get a URL for use in
 the CCADB as follows:

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -18,6 +18,8 @@ by clicking on their title.
 * Intermediate Certificates with Failed ALV Results
 * etc.
 
+Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
+
 **My CA**: Click on the 'My CA' tab to see the information that is in the CCADB
 for your CA, a hierarachy of root certiicates and intermediate certificates,
 and who the Points of Contact are for your CA.
@@ -33,11 +35,11 @@ lists of Cases.
 * Click on 'Recently Viewed' in the upper left corner. 
 * Select 'My Cases'
 then click on the thumb tack icon to pin this view as your default for this tab.
-    * Add/Update Root Request Cases are used for submitting [annual updates](updates).
+    * 'Add/Update Root Request' cases are used for submitting [annual updates](updates).
 
-**CA Communications**: The 'CA Communications' tab may be used when a root
-store operator polls their CA members for information. You may ignore this tab
-until you receive email from a root store operator asking you to respond to
+**CA Communications**: The 'CA Communications' tab may be used when a Root
+Store Operator polls CA Owners included in their program for information. You may ignore this tab
+until you receive email from a Root Store Operator asking you to respond to
 such a poll.
 
 **Reports**: Click on the 'Reports' tab (which may be under the 'More' tab), 

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -33,7 +33,7 @@ lists of Cases.
 * Click on 'Recently Viewed' in the upper left corner. 
 * Select 'My Cases'
 then click on the thumb tack icon to pin this view as your default for this tab.
-    * Audit Cases are used for submitting [annual updates](updates).
+    * Add/Update Root Request Cases are used for submitting [annual updates](updates).
 
 **CA Communications**: The 'CA Communications' tab may be used when a root
 store operator polls their CA members for information. You may ignore this tab

--- a/cas/inclusion.md
+++ b/cas/inclusion.md
@@ -1,8 +1,18 @@
 # Submit a Root Inclusion Request #
 
 The "Root Inclusion Request" case is used by a CA Owner to request that one or more of their root CA certificates be included in one or more Root Store Programs.
-* Instructions: [Create a Root Inclusion Request](https://docs.google.com/document/d/1FHSbpNJ3CQOcpVqrj66elKQhTmpllp-IBsDovPy6cOo/edit#)
 
-Root Store Member(s) review and process requests for inclusion in accordance with separate program requirements and within their own program timelines. The review process begins after a CA Owner has [added](https://www.ccadb.org/cas/updates) a root CA certificate to the CCADB and submitted a "Root Inclusion Request" to Root Store(s) for review.
+To **create a "Root Inclusion Request" case** in the CCADB:
+1. Click on the "My CA" tab.
+2. Click on the "CASES" tab under the CA Owner’s name, near the top left corner of the page.
+3. Click on the "New" button, which is on the right side of the page, below the "Get URLs" button.
+4. Select "Root Inclusion Request", and click on "Next".
+5. Type in information for the "Subject" (e.g., XYZ Root Certificates).
+6. Click on the "Save" button.
+    * There will be a green bar shown across the top of the page, which says “Case ###### was created". Click on the number in the list below (the same which was provided by green bar) to view the new case.
 
-Note: New required fields were added to CCADB Root Case records on December 22, 2022, and those fields will have to be populated in the "Root Inclusion Request” case to update a pre-existing Root Case record. Those fields will be in the applicable Root Program tab of the Root Inclusion Request case. CA Owners are expected to continue using the [Add/Update Root Request](https://www.ccadb.org/cas/updates) Case type to make necessary updates to CA Owner and Root Certificate records, such as policy and audit updates.
+* Detailed Instructions: [Create a Root Inclusion Request](https://docs.google.com/document/d/1FHSbpNJ3CQOcpVqrj66elKQhTmpllp-IBsDovPy6cOo/edit#)
+
+Root Store Operators review and process requests for inclusion in accordance with separate program requirements and within their own program timelines. The review process begins after a CA Owner has [added](https://www.ccadb.org/cas/updates) a root CA certificate to the CCADB and submitted a "Root Inclusion Request" case to Root Store(s) for review.
+
+Note: New required fields were added to CCADB Root Case records on December 22, 2022, and those fields will have to be populated in the "Root Inclusion Request” case to update a pre-existing Root Case record. Those fields will be in the applicable Root Program tab of the Root Inclusion Request case. CA Owners are expected to continue using the [Add/Update Root Request](https://www.ccadb.org/cas/updates) case type to make necessary updates to CA Owner and Root Certificate records, such as policy and audit updates.

--- a/cas/inclusion.md
+++ b/cas/inclusion.md
@@ -1,18 +1,18 @@
 # Submit a Root Inclusion Request #
 
-The "Root Inclusion Request" case is used by a CA Owner to request that one or more of their root CA certificates be included in one or more Root Store Programs.
+The 'Root Inclusion Request' case is used by a CA Owner to request that one or more of their root CA certificates be included in one or more Root Store Programs.
 
-To **create a "Root Inclusion Request" case** in the CCADB:
-1. Click on the "My CA" tab.
-2. Click on the "CASES" tab under the CA Owner’s name, near the top left corner of the page.
-3. Click on the "New" button, which is on the right side of the page, below the "Get URLs" button.
-4. Select "Root Inclusion Request", and click on "Next".
-5. Type in information for the "Subject" (e.g., XYZ Root Certificates).
-6. Click on the "Save" button.
+To **create a 'Root Inclusion Request' case** in the CCADB:
+1. Click on the 'My CA' tab.
+2. Click on the 'CASES' tab under the CA Owner’s name, near the top left corner of the page.
+3. Click on the 'New' button, which is on the right side of the page, below the 'Get URLs' button.
+4. Select 'Root Inclusion Request', and click on 'Next'.
+5. Type in information for the 'Subject' (e.g., XYZ Root Certificates).
+6. Click on the 'Save' button.
     * There will be a green bar shown across the top of the page, which says “Case ###### was created". Click on the number in the list below (the same which was provided by green bar) to view the new case.
 
 * Detailed Instructions: [Create a Root Inclusion Request](https://docs.google.com/document/d/1FHSbpNJ3CQOcpVqrj66elKQhTmpllp-IBsDovPy6cOo/edit#)
 
-Root Store Operators review and process requests for inclusion in accordance with separate program requirements and within their own program timelines. The review process begins after a CA Owner has [added](https://www.ccadb.org/cas/updates) a root CA certificate to the CCADB and submitted a "Root Inclusion Request" case to Root Store(s) for review.
+Root Store Operators review and process requests for inclusion in accordance with separate program requirements and within their own program timelines. The review process begins after a CA Owner has [added](https://www.ccadb.org/cas/updates) a root CA certificate to the CCADB and submitted a 'Root Inclusion Request' case to Root Store(s) for review.
 
-Note: New required fields were added to CCADB Root Case records on December 22, 2022, and those fields will have to be populated in the "Root Inclusion Request” case to update a pre-existing Root Case record. Those fields will be in the applicable Root Program tab of the Root Inclusion Request case. CA Owners are expected to continue using the [Add/Update Root Request](https://www.ccadb.org/cas/updates) case type to make necessary updates to CA Owner and Root Certificate records, such as policy and audit updates.
+Note: New required fields were added to CCADB Root Case records on December 22, 2022, and those fields will have to be populated in the 'Root Inclusion Request' case to update a pre-existing Root Case record. Those fields will be in the applicable Root Store Operator tab of the Root Inclusion Request case. CA Owners are expected to continue using the [Add/Update Root Request](https://www.ccadb.org/cas/updates) case type to make necessary updates to CA Owner and Root Certificate records, such as policy and audit updates.

--- a/cas/intermediates.md
+++ b/cas/intermediates.md
@@ -1,10 +1,12 @@
 # Managing Intermediate Certificates #
 
-CAs can view root and intermediate certificate data for all of the CAs in
-CCADB. However, CAs may only directly modify the intermediate certificate
-records for certificates chaining up to root certificates owned by their CA.
+CA Owners can view root and intermediate certificate data for all of the CAs in
+CCADB. However, CA Owners may only directly modify the intermediate certificate
+records for certificates chaining up to root certificates they own.
 
-CAs should consult the [CCADB Policy](/policy#4-intermediate-certificates)
+Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
+
+CA Owners should consult the [CCADB Policy](/policy#4-intermediate-certificates)
 about the requirements for disclosing intermediate certificate data 
 in the CCADB.
 
@@ -20,8 +22,8 @@ Table of Contents:
 
 ## Updating Audit Statements ##
 
-All CAs are required to update the audit and CP/CPS information for their 
-certificate hierarchies at least annually. CAs are expected to maintain their 
+All CA Owners are required to update the audit and CP/CPS information for their 
+certificate hierarchies at least annually. CA Owners are expected to maintain their 
 intermediate certificate records themselves and to directly enter the 
 corresponding updated audit statements via the following instructions. 
 Audit information for root certificate records must be provided via an 
@@ -108,10 +110,10 @@ use the 'Clone' button to save time. The recommended procedure is as follows:
 ## API ##
 
 [CCADB APIs](https://github.com/mozilla/CCADB-Tools/tree/master/API_AddUpdateIntermediateCert) 
-have been developed to enable CAs to automate retrieving and updating intermediate 
+have been developed to enable CA Owners to automate retrieving and updating intermediate 
 certificate data in the CCADB. This service is only available 
-to CAs whose root certificates are included within the root stores 
-of CCADB root store members.
+to CA Owners whose root certificates are included within the root stores 
+of CCADB Root Store Operators.
 * GetCertificateIdAPI: Returns the root or intermediate certificate record Id (Salesforce Id) in the CCADB.
 * AddUpdateIntermediateCertAPI: Add or update an intermediate certificate record in the CCADB.
 

--- a/cas/intermediates.md
+++ b/cas/intermediates.md
@@ -4,7 +4,7 @@ CAs can view root and intermediate certificate data for all of the CAs in
 CCADB. However, CAs may only directly modify the intermediate certificate
 records for certificates chaining up to root certificates owned by their CA.
 
-CAs should consult the [Common CCADB Policy](/policy#4-intermediate-certificates)
+CAs should consult the [CCADB Policy](/policy#4-intermediate-certificates)
 about the requirements for disclosing intermediate certificate data 
 in the CCADB.
 
@@ -25,7 +25,7 @@ certificate hierarchies at least annually. CAs are expected to maintain their
 intermediate certificate records themselves and to directly enter the 
 corresponding updated audit statements via the following instructions. 
 Audit information for root certificate records must be provided via an 
-[Audit Case](updates).
+[Add/Update Root Request Case](updates).
 
 **Important:** If the audit statements for an intermediate certificate are the 
 same as the certificate that signed it, then check the 'Audits Same as Parent' 

--- a/cas/public-group.md
+++ b/cas/public-group.md
@@ -14,7 +14,7 @@ The corresponding Root Store Operator may post announcements related to their pr
 The CCADB [policy](https://www.ccadb.org/policy) may be updated by the CCADB Steering Committee. A Root Store Operator may post an update to the policy in the public@ccadb.org group. The Root Store Operator may describe what is changing or has changed with the CCADB policy, link to supporting documentation, and state the effective date of the change.
 
 ## Lessons Learned from CA Incident Reports ##
-An important goal of incident reporting is to help all of us work together to build a more secure web. Therefore, [incident reports](https://wiki.mozilla.org/CA/Incident_Dashboard) should include lessons learned that could be helpful to all CAs to build better systems, and those lessons learned should be shared in the public@ccadb.org group.
+An important goal of incident reporting is to help all of us work together to build a more secure web. Therefore, [Incident Reports](https://www.ccadb.org/cas/incident-report) should include lessons learned that could be helpful to all CAs to build better systems, and those lessons learned should be shared in the public@ccadb.org group.
 
 ## Root Inclusion Public Discussion ##
 For those Root Stores that have public discussion, public@ccadb.org enables a single, shared public discussion phase for a CA Owner applying to such Root Store Programs. The CCADB root inclusion public discussion process promotes openness and transparency for applicants to public Root Stores. However, Root Store Programs will make final inclusion decisions independently, on their own timelines, and based on each Root Store Operator’s inclusion criteria.

--- a/cas/public-group.md
+++ b/cas/public-group.md
@@ -5,28 +5,28 @@ The public@ccadb.org [group](https://groups.google.com/a/ccadb.org/g/public) exi
 This page details the process and procedures for conducting discussion within the group as defined by the CCADB Steering Committee. 
 
 ## CCADB Updates ##
-An update to CCADB may include the addition of new functionality, the removal of previous functionality, or changes to the general availability of the system. A Root Store Member can post a message to public@ccadb.org to describe the type of update being made to CCADB.
+An update to CCADB may include the addition of new functionality, the removal of previous functionality, or changes to the general availability of the system. A Root Store Operator can post a message to public@ccadb.org to describe the type of update being made to CCADB.
 
 ## Root Store Program Announcements ##
-The corresponding Root Store Member may post announcements related to their program in the public@ccadb.org group. The Root Store Member may describe what is changing or has changed with the program, link to supporting documentation, and any other information it feels should be communicated publicly.
+The corresponding Root Store Operator may post announcements related to their program in the public@ccadb.org group. The Root Store Operator may describe what is changing or has changed with the program, link to supporting documentation, and any other information it feels should be communicated publicly.
 
 ## CCADB Policy Updates ##
-The CCADB [policy](https://www.ccadb.org/policy) may be updated by the CCADB Steering Committee. A Root Store Member may post an update to the policy in the public@ccadb.org group. The Root Store Member may describe what is changing or has changed with the CCADB policy, link to supporting documentation, and state the effective date of the change.
+The CCADB [policy](https://www.ccadb.org/policy) may be updated by the CCADB Steering Committee. A Root Store Operator may post an update to the policy in the public@ccadb.org group. The Root Store Operator may describe what is changing or has changed with the CCADB policy, link to supporting documentation, and state the effective date of the change.
 
 ## Lessons Learned from CA Incident Reports ##
 An important goal of incident reporting is to help all of us work together to build a more secure web. Therefore, [incident reports](https://wiki.mozilla.org/CA/Incident_Dashboard) should include lessons learned that could be helpful to all CAs to build better systems, and those lessons learned should be shared in the public@ccadb.org group.
 
 ## Root Inclusion Public Discussion ##
-For those root stores that have public discussion, public@ccadb.org enables a single, shared public discussion phase for a CA owner applying to such Root Store Programs. The CCADB root inclusion public discussion process promotes openness and transparency for applicants to public root stores. However, Root Store Programs will make final inclusion decisions independently, on their own timelines, and based on each Root Store Member’s inclusion criteria.
+For those Root Stores that have public discussion, public@ccadb.org enables a single, shared public discussion phase for a CA Owner applying to such Root Store Programs. The CCADB root inclusion public discussion process promotes openness and transparency for applicants to public Root Stores. However, Root Store Programs will make final inclusion decisions independently, on their own timelines, and based on each Root Store Operator’s inclusion criteria.
 
 ### Prerequisites ###
-Prior to a Root Store Member initiating a CCADB root inclusion public discussion, the following must occur:
+Prior to a Root Store Operator initiating a CCADB root inclusion public discussion, the following must occur:
 
-1. A CA owner must have an account in CCADB.
-2. A completed 'Add/Update Root Request' case must exist in CCADB for the root CA certificate(s). A completed case must include all required information set forth in each of the following tabs in the case: CA Owner, Audits, Policy Documents, Root Information, and if applicable, Test Websites. Specifically, required "Root Information" is:
+1. A CA Owner must have an account in CCADB.
+2. A completed 'Add/Update Root Request' case must exist in CCADB for the root CA certificate(s). A completed case must include all required information set forth in each of the following tabs in the case: CA OWNER, AUDITS, POLICY DOCUMENTS, ROOT INFORMATION, and if applicable, TEST WEBSITES. Specifically, required 'ROOT INFORMATION' is:
     * Background information that identifies why the CA needs to be considered for inclusion and the unique function of the CA.
     * The full CRL issued by the CA, or when there is no full CRL for the certificates issued by this CA, a JSON array whose elements are URLs of partial CRLs that when combined are the equivalent of a full CRL for the certificates issued by the CA.
-    * All "PKI Hierarchy Information", which details:
+    * All 'PKI Hierarchy Information', which details:
         * If the CA is cross-signed by another CA and/or another CA owner,
         * If the CA has externally operated subordinate CAs,
         * If the CA has external Registration Authorities,
@@ -36,19 +36,19 @@ Prior to a Root Store Member initiating a CCADB root inclusion public discussion
         * The TLS certificate validation methods that are available for use for certificates below the CA (if applicable).
     * A link to a completed [self assessment](https://www.ccadb.org/cas/self-assessment) for the CA.
     * A link to a Key Generation Audit Report for the CA.
-3. A 'Root Inclusion Request' case must have been submitted in CCADB, and one or more Root Store Members must be selected for inclusion.
+3. A 'Root Inclusion Request' case must have been submitted in CCADB, and one or more Root Store Programs must be selected for inclusion.
 
 ### Initiation ###
 No more than three concurrent CCADB root inclusion public discussions shall take place at any given time. If more than three 'Root Inclusion Request' cases have been submitted in CCADB, any requests for replacing an existing root CA certificate in CCADB will be prioritized for public discussion. Otherwise, CCADB public discussion will generally occur on a first-ready, first-out basis (to be ready for discussion). 
 
-A Root Store Member will initiate a six-week CCADB root inclusion public discussion in the public@ccadb.org group and provide information about the inclusion request from CCADB.
+A Root Store Operator will initiate a six-week CCADB root inclusion public discussion in the public@ccadb.org group and provide information about the inclusion request from CCADB.
 
-A CA owner is expected to respond to questions and concerns posted during the public discussion of their root CA certificate(s) inclusion request.
+A CA Owner is expected to respond to questions and concerns posted during the public discussion of their root CA certificate(s) inclusion request.
 
 ### Conclusion ###
-At the end of the six-week period, the CCADB root inclusion public discussion may be continued by the Root Store Member to complete ongoing discussions or matters under investigation. If public discussion is continued, the Root Store Member will state the additional amount of time (in weeks) that the conversation may continue. Otherwise, the CCADB public discussion concludes.
+At the end of the six-week period, the CCADB root inclusion public discussion may be continued by the Root Store Operator to complete ongoing discussions or matters under investigation. If public discussion is continued, the Root Store Operator will state the additional amount of time (in weeks) that the conversation may continue. Otherwise, the CCADB public discussion concludes.
 
-The Root Store Member who initiated the public discussion provides a summary noting any objections or open questions that did not receive a response from the CA owner and states the public discussion period has concluded.
+The Root Store Operator who initiated the public discussion provides a summary noting any objections or open questions that did not receive a response from the CA Owner and states the public discussion period has concluded.
 
 ## Cross-Certificate Requests ##
-Individual Root Store Program policies may require CA owners to notify public@ccadb.org before issuing a cross-certificate that can validate to a corresponding root CA certificate in the Root Store Member’s trust store. If required, the Root Store Program policy should stipulate the content required in the notification.
+Individual Root Store policies may require CA Owners to notify public@ccadb.org before issuing a cross-certificate that can validate to a corresponding root CA certificate in the Root Store Operator’s trust store. If required, the Root Store policy should stipulate the content required in the notification.

--- a/cas/request-access.md
+++ b/cas/request-access.md
@@ -1,16 +1,16 @@
 # Request Access #
 
-CCADB licenses are intended for root store operators and the certification authorities (CAs) who are in their programs, with the intention of jointly maintaining overlapping data about the CAs in their programs. A license should not generally be required to view CCADB data, because most of the non-personally-identifying information in the CCADB is published via URLs provided on [this website](https://ccadb.org/resources) as well as on the root store operator websites.
+CCADB licenses are intended for Root Store Operators and the Certification Authorities (CAs) who are in their programs, with the intention of jointly maintaining overlapping data about the CAs in their programs. A license should not generally be required to view CCADB data, because most of the non-personally-identifying information in the CCADB is published via URLs provided on [this website](https://ccadb.org/resources) as well as on the Root Store Operator websites.
 
-[Root Store Members](https://ccadb.org/rootstores/how) of the CCADB share the cost in the maintenance of the CRM service, customization, and license fees. CAs are not currently charged a fee to have a CCADB CA Community License, because those licenses are paid for by the root store members.
+[Root Store Operators](https://ccadb.org/rootstores/how) of the CCADB share the cost in the maintenance of the CRM service, customization, and license fees. CAs are not currently charged a fee to have a CCADB CA Community License, because those licenses are paid for by the Root Store Operators.
 
-The Root Store Members of the CCADB reserve the right to not provide CCADB access to an organization for any reason or no reason at all.
+The Root Store Operators of the CCADB reserve the right to not provide CCADB access to an organization for any reason or no reason at all.
 
-To get access to the CCADB the organization must be sponsored by a Root Store Member of the CCADB. To be sponsored, the CA will either have a root certificate included in one or more of the Root Store Members’ programs, or be in the process of requesting root certificate inclusion into one or more of the Root Store Members’ programs. 
+To get access to the CCADB the organization must be sponsored by a Root Store Operator of the CCADB. To be sponsored, the CA will either have a root certificate included in one or more of the Root Store Operators’ programs, or be in the process of requesting root certificate inclusion into one or more of the Root Store Operators’ programs. 
 
 The CCADB is a highly customized instance of the Salesforce CRM, so as part of your application for CCADB access, you must review the [Salesforce Terms of Service](https://www.salesforce.com/company/legal/sfdc-website-terms-of-service/) and state that you can abide by it. CCADB CA Community licenses may only be issued to individuals who officially represent the CA.
 
-Some of the Root Store Members of the CCADB require contractual agreements with the CAs in their program. Therefore, your CA organization must be capable of entering into a contractual agreement with a [US-based](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) company.
+Some of the Root Store Operators of the CCADB require contractual agreements with the CAs in their program. Therefore, your CA organization must be capable of entering into a contractual agreement with a [US-based](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) company.
 
 ## Application for CCADB Access ##
 
@@ -18,7 +18,7 @@ If your CA is new to the CCADB, then [submit this form](https://ccadb-public.sec
 
 The CCADB is a highly customized instance of Salesforce, so in the access request form you must confirm that you can abide by the [Salesforce Terms of Service](https://www.salesforce.com/company/legal/sfdc-website-terms-of-service/). Note that Salesforce prevents access in [some global regions](https://trust.salesforce.com/en/blocked/) as indicated in section 14.1 of the [Salesforce Master Subscription Agreement](https://a.sfdcstatic.com/content/dam/www/ocms-backup/assets/pdf/misc/salesforce_MSA.pdf).
 
-If there are any questions about the completeness of your application, we will get back to you. Otherwise, once we have received this information, we will make a determination on whether your organization is sponsored by a Root Store Member of the CCADB to receive access to the CCADB. If it is determined that your CA may receive access to the CCADB, then a CCADB CA Community license will be issued to the CA’s representative’s email address provided in the form, and that individual will receive an email with further instructions.
+If there are any questions about the completeness of your application, we will get back to you. Otherwise, once we have received this information, we will make a determination on whether your organization is sponsored by a Root Store Operator of the CCADB to receive access to the CCADB. If it is determined that your CA may receive access to the CCADB, then a CCADB CA Community license will be issued to the CA’s representative’s email address provided in the form, and that individual will receive an email with further instructions.
 
 ## Changing CCADB Licenses ##
 

--- a/cas/self-assessment.md
+++ b/cas/self-assessment.md
@@ -1,8 +1,8 @@
 # CCADB Self Assessment #
 
-Self assessments are valuable. They allow CA owners to reflect and make objective judgments and self learnings based on criteria they have agreed to follow. They also provide Root Stores with transparency and assurance that controls are in place and operating effectively to maintain privacy and security for end users. Finally, they provide an opportunity for continuous improvement by either calling attention to policy requirements that may be misinterpreted or otherwise benefit from enhancement or modernization.
+Self assessments are valuable. They allow CA Owners to reflect and make objective judgments and self learnings based on criteria they have agreed to follow. They also provide Root Store Operators with transparency and assurance that controls are in place and operating effectively to maintain privacy and security for end users. Finally, they provide an opportunity for continuous improvement by either calling attention to policy requirements that may be misinterpreted or otherwise benefit from enhancement or modernization.
 
-Some Root Stores may require the completion of a self assessment using the CCADB template at various times to evaluate the conformance of the CA owner's policies against industry policies and practices. 
+Some Root Store policies may require the completion of a self assessment using the CCADB template at various times to evaluate the conformance of the CA Owner's policies against industry policies and practices. 
 
 * Template: [CCADB Self Assessment](https://docs.google.com/spreadsheets/d/1ahHjFP74rgrNJExTd1molihw6UBJ0zAVs12hNGKG56g/edit?usp=sharing)
 

--- a/cas/updates.md
+++ b/cas/updates.md
@@ -2,7 +2,7 @@
 
 The "Add/Update Root Request" case is used to request that Root Certificate records be added to the CCADB, and to request updates to CA Owner and Root Certificate records such as policy and audit updates.
 
-To **create an "Add/Update Root Request** in the CCADB:
+To **create an "Add/Update Root Request" case** in the CCADB:
 1. Click on the "My CA" tab.
 2. Click on the "CASES" tab under the CA Owner’s name, near the top left corner of the page.
 3. Click on the "New" button, which is on the right side of the page, below the "Get URLs" button.

--- a/cas/updates.md
+++ b/cas/updates.md
@@ -1,36 +1,36 @@
 # Add and Update Root Certificate Records #
 
-The "Add/Update Root Request" case is used to request that Root Certificate records be added to the CCADB, and to request updates to CA Owner and Root Certificate records such as policy and audit updates.
+The 'Add/Update Root Request' case is used to request that Root Certificate records be added to the CCADB, and to request updates to CA Owner and Root Certificate records such as policy and audit updates.
 
-To **create an "Add/Update Root Request" case** in the CCADB:
-1. Click on the "My CA" tab.
-2. Click on the "CASES" tab under the CA Owner’s name, near the top left corner of the page.
-3. Click on the "New" button, which is on the right side of the page, below the "Get URLs" button.
-4. Select "Add/Update Root Request", and click on "Next".
-5. Type in information for the "Subject" (e.g. Example CA New Root Certificates).
-6. Click on the "Save" button.
+To **create an 'Add/Update Root Request' case** in the CCADB:
+1. Click on the 'My CA' tab.
+2. Click on the 'CASES' tab under the CA Owner’s name, near the top left corner of the page.
+3. Click on the 'New' button, which is on the right side of the page, below the 'Get URLs' button.
+4. Select 'Add/Update Root Request', and click on 'Next'.
+5. Type in information for the 'Subject' (e.g. Example CA New Root Certificates).
+6. Click on the 'Save' button.
     * There will be a green bar shown across the top of the page, which says “Case ###### was created". Click on the number in the list below (the same which was provided by green bar) to view the new case.
-    * Otherwise, go back to the "CASES" tab in "My CA", and click on the number in the top row of the "Case" column.
+    * Otherwise, go back to the 'CASES' tab in 'My CA', and click on the number in the top row of the 'Case' column.
 
 * Detailed Instructions: [Create an Add/Update Root Request](https://docs.google.com/document/d/1AUbwbyqCq3jR7wP0fSWjL1us9s4sZIbXGRyo_ko77QM/edit)
 
-The "Add/Update Root Request" case contains the following tabs, and you may choose which tabs to make updates in. For example, if you are providing policy document updates inbetween annual audits, then you may only want to update the POLICY DOCUMENTS tab. 
+The 'Add/Update Root Request' case contains the following tabs, and you may choose which tabs to make updates in. For example, if you are providing policy document updates inbetween annual audits, then you may only want to update the POLICY DOCUMENTS tab. 
 
-Note: New required fields were added to Root Certificate records on September 15, 2022, and those fields will have to be filled in the next time an "Add/Update Root Request" case is used to update a pre-existing Root Certificate record. Those fields are in the "ROOT INFORMATION" tab.
+Note: New required fields were added to Root Certificate records on September 15, 2022, and those fields will have to be filled in the next time an 'Add/Update Root Request' case is used to update a pre-existing Root Certificate record. Those fields are in the 'ROOT INFORMATION' tab.
 * CA OWNER
 * AUDITS
 * POLICY DOCUMENTS
 * ROOT INFORMATION
 * TEST WEBSITES
 
-To **add a Root Certificate record to the CCADB**, view the instructions for the "ROOT INFORMATION" tab. High level instructions:
-1. Go to the "ROOT INFORMATION" tab.
-2. Click on the "Add/Select Root Certificates" button.
-3. Click on the "Add Root Certificate to CCADB" button.
-4. Paste the certificate PEM into the window and click on "Validate PEM".
-5. If validation is successful, click on the "Create Root Certificate in CCADB" button.
-6. Fill in the data for the required fields in the "ROOT INFORMATION" tab.
-7. Click on the "Submit to Root Store" button.
+To **add a Root Certificate record to the CCADB**, view the instructions for the 'ROOT INFORMATION' tab. High level instructions:
+1. Go to the 'ROOT INFORMATION' tab.
+2. Click on the 'Add/Select Root Certificates' button.
+3. Click on the 'Add Root Certificate to CCADB' button.
+4. Paste the certificate PEM into the window and click on 'Validate PEM'.
+5. If validation is successful, click on the 'Create Root Certificate in CCADB' button.
+6. Fill in the data for the required fields in the 'ROOT INFORMATION' tab.
+7. Click on the 'Submit to Root Store' button.
 
 CAs in the CCADB are organized into hierarchies. Each CA Owner has children nodes that are Root Certificate records, and Root Certificate records have children nodes that are Intermediate Certificate records, and Intermediate Certificate records have children nodes that are Intermediate Certificate records. 
 

--- a/cas/updates.md
+++ b/cas/updates.md
@@ -1,7 +1,18 @@
 # Add and Update Root Certificate Records #
 
 The "Add/Update Root Request" case is used to request that Root Certificate records be added to the CCADB, and to request updates to CA Owner and Root Certificate records such as policy and audit updates.
-* Instructions: [Create an Add/Update Root Request](https://docs.google.com/document/d/1AUbwbyqCq3jR7wP0fSWjL1us9s4sZIbXGRyo_ko77QM/edit)
+
+To **create an "Add/Update Root Request** in the CCADB:
+1. Click on the "My CA" tab.
+2. Click on the "CASES" tab under the CA Owner’s name, near the top left corner of the page.
+3. Click on the "New" button, which is on the right side of the page, below the "Get URLs" button.
+4. Select "Add/Update Root Request", and click on "Next".
+5. Type in information for the "Subject" (e.g. Example CA New Root Certificates).
+6. Click on the "Save" button.
+    * There will be a green bar shown across the top of the page, which says “Case ###### was created". Click on the number in the list below (the same which was provided by green bar) to view the new case.
+    * Otherwise, go back to the "CASES" tab in "My CA", and click on the number in the top row of the "Case" column.
+
+* Detailed Instructions: [Create an Add/Update Root Request](https://docs.google.com/document/d/1AUbwbyqCq3jR7wP0fSWjL1us9s4sZIbXGRyo_ko77QM/edit)
 
 The "Add/Update Root Request" case contains the following tabs, and you may choose which tabs to make updates in. For example, if you are providing policy document updates inbetween annual audits, then you may only want to update the POLICY DOCUMENTS tab. 
 
@@ -13,26 +24,18 @@ Note: New required fields were added to Root Certificate records on September 15
 * TEST WEBSITES
 
 To **add a Root Certificate record to the CCADB**, view the instructions for the "ROOT INFORMATION" tab. High level instructions:
-1. Go to the "ROOT INFORMATION" tab
-2. Click on the "Add/Select Root Certificates" button
-3. Click on the "Add Root Certificate to CCADB" button
-4. Paste the certificate PEM into the window and click on "Validate PEM"
-5. If validation is successful, click on the "Create Root Certificate in CCADB" button
-6. Fill in the data for the required fields in the "ROOT INFORMATION" tab
-7. Click on the "Submit to Root Store" button
+1. Go to the "ROOT INFORMATION" tab.
+2. Click on the "Add/Select Root Certificates" button.
+3. Click on the "Add Root Certificate to CCADB" button.
+4. Paste the certificate PEM into the window and click on "Validate PEM".
+5. If validation is successful, click on the "Create Root Certificate in CCADB" button.
+6. Fill in the data for the required fields in the "ROOT INFORMATION" tab.
+7. Click on the "Submit to Root Store" button.
 
-CAs in the CCADB are organized into hierarchies. Each CA Owner has children
-nodes that are Root Certificate records, and Root Certificate records have children
-nodes that are Intermediate Certificate records, and Intermediate Certificate
-records have children nodes that are Intermediate Certificate records. 
+CAs in the CCADB are organized into hierarchies. Each CA Owner has children nodes that are Root Certificate records, and Root Certificate records have children nodes that are Intermediate Certificate records, and Intermediate Certificate records have children nodes that are Intermediate Certificate records. 
 
-All CAs are required to update the audit, CP, CPS and test website information
-for their certificate hierarchies at least annually. CAs are expected to
-maintain their [**intermediate**](intermediates) certificate records themselves
-and to directly enter the corresponding [updated audit
-statements](fields#audit-information). However, **root** certificate data
-cannot be self-maintained, because root store operators must verify the data 
-before the CA Owner or Root Certificate records are modified.
+Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
+All CAs are required to update the audit, CP, CPS and test website information for their certificate hierarchies at least annually. CAs are expected to maintain their [**intermediate**](intermediates) certificate records themselves and to directly enter the corresponding [updated audit statements](fields#audit-information). However, **root** certificate data cannot be self-maintained, because root store operators must verify the data before the CA Owner or Root Certificate records are modified.
 
 

--- a/index.md
+++ b/index.md
@@ -1,12 +1,12 @@
 ![CCADB](images/big-logo.png){:width="200px" style="float: right" }
 
 The Common CA Database (CCADB) is a repository of information about
-externally operated Certificate Authorities (CAs) whose root and
+externally operated Certification Authorities (CAs) whose root and
 intermediate certificates are included within 
-the products and services of CCADB root store members.
-Root store operators participate in the CCADB to improve security,
+the products and services of CCADB Root Store Operators.
+Root Store Operators participate in the CCADB to improve security,
 transparency, and interoperability.
 The CCADB is used by a number of different
-root store operators to manage their root stores, but it is run by
+Root Store Operators to manage their root stores, but it is run by
 [Mozilla](https://www.mozilla.org/mission/).
 

--- a/rootstores/how.md
+++ b/rootstores/how.md
@@ -2,7 +2,7 @@
 
 If you are a browser manufacturer or developer of software that includes
 a trusted root certificate store that you actively manage, you may wish to
-consider joining the CCADB as a Root Store Member.
+consider joining the CCADB as a Root Store Operator.
 
 ## Membership Requirements ##
 
@@ -15,10 +15,10 @@ Applicants for membership must:
 * Comply with [Mozilla's terms](usage) governing usage of the CCADB.
 
 In addition, participation in the CCADB is at Mozilla’s
-discretion. Mozilla reserves the right not to include a particular root store
-operator in the CCADB, and not to issue a license to the Common
+discretion. Mozilla reserves the right not to include a particular Root Store
+Operator in the CCADB, and not to issue a license to the Common
 CA Database for any or no reason, including without limitation cases where we
-believe that including or issuing a license to a root store operator would
+believe that including or issuing a license to a Root Store Operator would
 interfere with the operation or security of the CCADB, or would
 breach our agreements with the underlying CRM.
 
@@ -49,7 +49,7 @@ application:
 
 If there are any questions about your application, we will get back to you.
 Otherwise, once we have received this information, Mozilla will make a
-determination on whether to include your organization as a Root Store Member
+determination on whether to include your organization as a Root Store Operator
 and communicate its determination to you, along with any information about your
 membership and participation.
 

--- a/rootstores/index.md
+++ b/rootstores/index.md
@@ -3,5 +3,5 @@
 * [Login to CCADB](https://ccadb.my.salesforce.com/)
 * [CCADB Usage Terms](usage)
 * [CCADB Steering Committee](https://docs.google.com/document/d/1U0nF59Im1Eu46QUhFHnU8VL6_JhTTtW66VRIJH9KIkA/edit#heading=h.pyq8c6x56e0a)
-* [Why Become a Root Store Member?](why)
-* [How to Become a Root Store Member](how)
+* [Why Become a Member?](why)
+* [How to Become a Member](how)

--- a/rootstores/usage.md
+++ b/rootstores/usage.md
@@ -21,15 +21,15 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS DATA, EVEN 
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## CCADB Root Store Member Usage Terms ##
+## CCADB Root Store Operator Usage Terms ##
 As permitted by section 4 of the [Common CA Database
 Agreement](mozilla-ccadb-agreement.pdf), and in addition to any other requirements set out
-therein, Mozilla sets some usage terms and rules for Root Store Members using
+therein, Mozilla sets some usage terms and rules for Root Store Operators using
 the CCADB, as follows.
 
 ### Meetings ###
 
-Root Store Members of the CCADB may meet by teleconference or
+Root Store Operators of the CCADB may meet by teleconference or
 at face-to-face meetings for the purpose of discussing improvements or changes
 to the operation of the CCADB. Such discussions should not include
 competitively-sensitive information. Mozilla shall not be responsible for the
@@ -37,21 +37,21 @@ expenses of any such teleconferences or meetings.
 
 ### Customizing the CCADB ###
 
-A Root Store Member may make customization changes that only impact itself.
+A Root Store Operator may make customization changes that only impact itself.
 Before being applied to the production instance of the CCADB,
 changes will be reviewed and tested by Mozilla (or its representative),
 including to ensure that the changes will not negatively impact any of the
-other Members or the CCADB. Mozilla will either approve or decline
+other Operators or the CCADB. Mozilla will either approve or decline
 the proposed changes. If the changes are approved, then a Mozilla
 representative will apply the changes to the production instance of the Common
 CA Database. If the changes are denied, then the Mozilla representative will
-provide an explanation, and the Member organization may submit the
+provide an explanation, and the Operator organization may submit the
 customizations again after addressing the feedback.
 
-Root Store Members may request customization changes that impact shared data
+Root Store Operators may request customization changes that impact shared data
 and interfaces. Mozilla (or its representative) will review, and approve or
 deny such requests. If the request is approved, Mozilla will prioritize the
-requested changes, and work with the members to design and test the changes in
+requested changes, and work with the Operators to design and test the changes in
 a sandbox environment before applying them to the production instance of the
 CCADB.
 
@@ -60,10 +60,10 @@ available on [GitHub][CCADB-Github].
 
 ### Appropriate Data ###
 
-Root Store Members may store the following types of data in the Common CA
-Database, as it pertains to the management of their root store programs.
+Root Store Operators may store the following types of data in the Common CA
+Database, as it pertains to the management of their Root Store Programs.
 Aside from contact information, data uploaded to the Common CA Database is 
-made generally available to the public,
+made generally available to the public:
 
 * CA and subordinate CA certificate data;
 * CA Owner information (CA name, company website, physical address, etc.);
@@ -77,7 +77,7 @@ made generally available to the public,
   requests;
 * Dates and comments relating to root and intermediate certificates.
 
-Root Store Members shall **not** store the following types of data in the
+Root Store Operators shall **not** store the following types of data in the
 CCADB:
 
 * Confidential data

--- a/rootstores/why.md
+++ b/rootstores/why.md
@@ -3,36 +3,32 @@
 While maintaining an up-to-date root store containing only credible CAs is
 important and necessary for many organizations to help keep their end users
 safe, it is usually not done for profit and is not a strategic area for core
-business. Much of the data that root store operators maintain for their CA
+business. Much of the data that Root Store Operators maintain for their
 programs is common and public data. Participating in the Common CA Database
 (CCADB) will pave the way for better, more efficient and more cost-effective
 management of your root store, making the internet safer for everyone.
 
 The CCADB has the following capabilities:
 
-* Automates notification to CAs when updated audit statements are due.
-* Enables multiple people to share in the maintenance of the CA and subCA data
+* Automates notification to CA Owners when updated audit statements are due.
+* Enables multiple people to share in the maintenance of the CA Owner and CA certificate data
   (CP/CPS links, audit links/dates/auditor qualifications, Points of Contact,
   etc.)
-* Automates sending of communications to CAs and receiving and analyzing their
+* Automates sending of communications to CA Owners and receiving and analyzing their
   responses.
 * Makes it easier to review information and status associated with root
   inclusion requests.
 * Tracks non-technically-constrained intermediate certificates.
+* Permits a CA Owner to apply to multiple root stores with a single request.
 * Makes your CA program more transparent.
 
-In the future, the CCADB will:
-
-* Permit a CA to apply to multiple root stores with a single application
-  process.
-
-Root Store Members can:
+Root Store Operators can:
 
 * Access the CCADB.
 * Independently operate and make decisions on root inclusion/change requests,
   and verify audit data for their root stores.
-* Send email to all CAs in their program according to specified criteria.
-* Automate sending reminders to CAs about when periodic updates are due.
+* Send email to all CA Owners in their program according to specified criteria.
+* Automate sending reminders to CA Owners about when periodic updates are due.
 * Share their findings in verifying data related to root and intermediate
   certificates; including annual audits, policy documentation, contact
   information, etc.
@@ -46,11 +42,11 @@ Root Store Members can:
 ## Cost ##
 
 The cost of operating and maintaining the CCADB is shared among
-the Root Store Members. Mozilla’s goal in sharing the CCADB is to
+the Root Store Operators. Mozilla’s goal in sharing the CCADB is to
 improve the quality of the CA data and help keep end users safe. It is
 expressly not a goal of Mozilla to make money from sharing the CCADB.
 
-Currently, the following types of costs are shared among Root Store Members:
+Currently, the following types of costs are shared among Root Store Operators:
 
 * Subscription fees and other costs imposed by the underlying CRM (e.g.,
   Community and Enterprise license costs).
@@ -59,5 +55,5 @@ Currently, the following types of costs are shared among Root Store Members:
 
 These categories of costs are subject to change.
 
-Interested in becoming a Root Store Member? [See how](how).
+Interested in becoming a Root Store Operator in the CCADB? [See how](how).
 


### PR DESCRIPTION
Updated instances of CCADB “Audit Case” to “Add/Update Root Request Case”.
Corrected CCADB policy reference statements after the update to v1.2.
Replaced instances of “Root Store Member” with “Root Store Operator”.
Where appropriate, replaced instances of “CA” with “CA Owner”.
Added the “Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.” in several locations, when appropriate.
Added high-level steps for creating an "Add/Update Root Request" and "Root Inclusion Request" case.
Other general cleanup items for consistency.