### PR TITLE
Removed 'CA Communications' from getting-started.md

### DIFF
--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -20,7 +20,7 @@ Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
 **Cases**: Click on the 'Cases' tab (which may be under the 'More' tab) to see lists of Cases.
 * Click on 'Recently Viewed' in the upper left corner. 
-* Select 'My Cases' then click on the thumb tack icon to pin this view as your default for this tab.
+* Select 'My Cases', then click on the thumbtack icon to pin this view as your default for this tab.
     * '[Add/Update Root Request](updates)' cases are used for adding new root CA certificates or submitting annual updates.
     * '[Root Inclusion Request](inclusion)' cases are used for submitting requests for inclusion to Root Store Programs.
     * '[Add/Update Contacts](contacts)' cases are used to add or udpate POC information. 

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with the CCADB #
 
-When you [login](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979F8eil5bBQGKjaWRc/edit#heading=h.xpgou83dsc4m) to the CCADB you will see a row of tabs along the top  of the window, next to the CCADB logo. The number of tabs that you see depends on the width of your window, and a 'More' tab will be shown when all of the tabs cannot be displayed. The tabs are: 'Home', 'My CA', 'CA Owners/Certificates', 'Cases', and 'Reports'.
+When you [login](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979F8eil5bBQGKjaWRc/edit#heading=h.xpgou83dsc4m) to the CCADB you will see a row of tabs along the top of the window, next to the CCADB logo. The number of tabs that you see depends on the width of your window, and a 'More' tab will be shown when all of the tabs cannot be displayed. The tabs are: 'Home', 'My CA', 'CA Owners/Certificates', 'Cases', and 'Reports'.
 
 **Home**: The home page is the initial page that you see when you login. It provides your CA's task list which is a set of reports that may be openned by clicking on their title.
 * Open Cases

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -14,7 +14,7 @@ Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
 **My CA**: Click on the 'My CA' tab to see your CA information in the CCADB (including Points of Contact), a hierarchy of root certificates and intermediate certificates, and all cases, reports, and communications for your CA.
 
-**CA Owners/Certificates**: Click on the 'CA Owners/Certificates' tab  (which may be under the 'More' tab) to see lists of certificates. 
+**CA Owners/Certificates**: Click on the 'CA Owners/Certificates' tab (which may be under the 'More' tab) to see lists of certificates. 
 * Click on 'Recently Viewed' in the upper left corner. 
 * Select 'Community User's CA Owners/Root Certs' then click on the thumb tack icon to pin this view as your default for this tab.
 

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -25,7 +25,7 @@ Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
     * '[Root Inclusion Request](inclusion)' cases are used for submitting requests for inclusion to Root Store Programs.
     * '[Add/Update Contacts](contacts)' cases are used to add or update POC information. 
 
-**Reports**: Click on the 'Reports' tab (which may be under the 'More' tab), then click on 'All Folders' along the left column, and then click on 'CA Community Reports'.
+**Reports**: Click on the 'Reports' tab (which may be under the 'More' tab), then click 'All Folders' along the left column, and then click 'CA Community Reports'.
 
 [CCADB-Login]: https://ccadb.force.com/
 

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -16,7 +16,7 @@ Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
 **CA Owners/Certificates**: Click on the 'CA Owners/Certificates' tab (which may be under the 'More' tab) to see lists of certificates. 
 * Click on 'Recently Viewed' in the upper left corner. 
-* Select 'Community User's CA Owners/Root Certs' then click on the thumb tack icon to pin this view as your default for this tab.
+* Select 'Community User's CA Owners/Root Certs', then click on the thumbtack icon to pin this view as your default for this tab.
 
 **Cases**: Click on the 'Cases' tab (which may be under the 'More' tab) to see  lists of Cases.
 * Click on 'Recently Viewed' in the upper left corner. 

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -23,7 +23,7 @@ Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 * Select 'My Cases', then click on the thumbtack icon to pin this view as your default for this tab.
     * '[Add/Update Root Request](updates)' cases are used for adding new root CA certificates or submitting annual updates.
     * '[Root Inclusion Request](inclusion)' cases are used for submitting requests for inclusion to Root Store Programs.
-    * '[Add/Update Contacts](contacts)' cases are used to add or udpate POC information. 
+    * '[Add/Update Contacts](contacts)' cases are used to add or update POC information. 
 
 **Reports**: Click on the 'Reports' tab (which may be under the 'More' tab), then click on 'All Folders' along the left column, and then click on 'CA Community Reports'.
 

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -1,16 +1,8 @@
 # Getting Started with the CCADB #
 
-When you [login](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979F8eil5bBQGKjaWRc/edit#heading=h.xpgou83dsc4m) 
-to the CCADB you will see a row of tabs along the top 
-of the window, next to the CCADB logo. The number of tabs that you
-see depends on the width of your window, and a 'More' tab will
-be shown when all of the tabs cannot be displayed. The tabs are:
-'Home', 'My CA', 'CA Owners/Certificates', 'Cases', 'CA Communications', 
-and 'Reports'.
+When you [login](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979F8eil5bBQGKjaWRc/edit#heading=h.xpgou83dsc4m) to the CCADB you will see a row of tabs along the top  of the window, next to the CCADB logo. The number of tabs that you see depends on the width of your window, and a 'More' tab will be shown when all of the tabs cannot be displayed. The tabs are: 'Home', 'My CA', 'CA Owners/Certificates', 'Cases', and 'Reports'.
 
-**Home**: The home page is the initial page that you see when you login.
-It provides your CA's task list which is a set of reports that may be openned
-by clicking on their title.
+**Home**: The home page is the initial page that you see when you login. It provides your CA's task list which is a set of reports that may be openned by clicking on their title.
 * Open Cases
 * Root Certificates with Outdated Audit Statements
 * Intermediate Certificate with Outdated Audit Statements
@@ -20,33 +12,20 @@ by clicking on their title.
 
 Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
-**My CA**: Click on the 'My CA' tab to see the information that is in the CCADB
-for your CA, a hierarachy of root certiicates and intermediate certificates,
-and who the Points of Contact are for your CA.
+**My CA**: Click on the 'My CA' tab to see your CA information that is in the CCADB (including Points of Contact), a hierarachy of root certiicates and intermediate certificates, and all cases, reports, and communications for your CA.
 
-**CA Owners/Certificates**: Click on the 'CA Owners/Certificates' tab 
-(which may be under the 'More' tab) to see lists of certificates. 
+**CA Owners/Certificates**: Click on the 'CA Owners/Certificates' tab  (which may be under the 'More' tab) to see lists of certificates. 
 * Click on 'Recently Viewed' in the upper left corner. 
-* Select 'Community User's CA Owners/Root Certs'
-then click on the thumb tack icon to pin this view as your default for this tab.
+* Select 'Community User's CA Owners/Root Certs' then click on the thumb tack icon to pin this view as your default for this tab.
 
-**Cases**: Click on the 'Cases' tab (which may be under the 'More' tab) to see 
-lists of Cases.
+**Cases**: Click on the 'Cases' tab (which may be under the 'More' tab) to see  lists of Cases.
 * Click on 'Recently Viewed' in the upper left corner. 
-* Select 'My Cases'
-then click on the thumb tack icon to pin this view as your default for this tab.
+* Select 'My Cases' then click on the thumb tack icon to pin this view as your default for this tab.
     * '[Add/Update Root Request](updates)' cases are used for adding new root CA certificates or submitting annual updates.
     * '[Root Inclusion Request](inclusion)' cases are used for submitting requests for inclusion to Root Store Programs.
     * '[Add/Update Contacts](contacts)' cases are used to add or udpate POC information. 
 
-**CA Communications**: The 'CA Communications' tab may be used when a Root
-Store Operator polls CA Owners included in their program for information. You may ignore this tab
-until you receive email from a Root Store Operator asking you to respond to
-such a poll.
-
-**Reports**: Click on the 'Reports' tab (which may be under the 'More' tab), 
-then click on 'All Folders' along the left column, and then click on 
-'CA Community Reports'.
+**Reports**: Click on the 'Reports' tab (which may be under the 'More' tab), then click on 'All Folders' along the left column, and then click on 'CA Community Reports'.
 
 [CCADB-Login]: https://ccadb.force.com/
 

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with the CCADB #
 
-When you [login](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979F8eil5bBQGKjaWRc/edit#heading=h.xpgou83dsc4m) to the CCADB you will see a row of tabs along the top of the window, next to the CCADB logo. The number of tabs that you see depends on the width of your window, and a 'More' tab will be shown when all of the tabs cannot be displayed. The tabs are: 'Home', 'My CA', 'CA Owners/Certificates', 'Cases', and 'Reports'.
+When you [log in](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979F8eil5bBQGKjaWRc/edit#heading=h.xpgou83dsc4m) to the CCADB you will see a row of tabs along the top of the window, next to the CCADB logo. The number of tabs that you see depends on the width of your window, and a 'More' tab will be shown when all of the tabs cannot be displayed. The tabs are: 'Home', 'My CA', 'CA Owners/Certificates', 'Cases', and 'Reports'.
 
 **Home**: The home page is the initial page that you see when you log in. It provides your CA's task list, a set of reports that may be opened by clicking on their title.
 * Open Cases

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -2,7 +2,7 @@
 
 When you [login](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979F8eil5bBQGKjaWRc/edit#heading=h.xpgou83dsc4m) to the CCADB you will see a row of tabs along the top of the window, next to the CCADB logo. The number of tabs that you see depends on the width of your window, and a 'More' tab will be shown when all of the tabs cannot be displayed. The tabs are: 'Home', 'My CA', 'CA Owners/Certificates', 'Cases', and 'Reports'.
 
-**Home**: The home page is the initial page that you see when you login. It provides your CA's task list which is a set of reports that may be openned by clicking on their title.
+**Home**: The home page is the initial page that you see when you log in. It provides your CA's task list, a set of reports that may be opened by clicking on their title.
 * Open Cases
 * Root Certificates with Outdated Audit Statements
 * Intermediate Certificate with Outdated Audit Statements

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -18,7 +18,7 @@ Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 * Click on 'Recently Viewed' in the upper left corner. 
 * Select 'Community User's CA Owners/Root Certs', then click on the thumbtack icon to pin this view as your default for this tab.
 
-**Cases**: Click on the 'Cases' tab (which may be under the 'More' tab) to see  lists of Cases.
+**Cases**: Click on the 'Cases' tab (which may be under the 'More' tab) to see lists of Cases.
 * Click on 'Recently Viewed' in the upper left corner. 
 * Select 'My Cases' then click on the thumb tack icon to pin this view as your default for this tab.
     * '[Add/Update Root Request](updates)' cases are used for adding new root CA certificates or submitting annual updates.

--- a/cas/getting-started.md
+++ b/cas/getting-started.md
@@ -12,7 +12,7 @@ When you [login](https://docs.google.com/document/d/1MuszDO2o-es_6-FwNCDWZ2TC979
 
 Note: The CCADB considers the terms "intermediate" and "subordinate" synonymous.
 
-**My CA**: Click on the 'My CA' tab to see your CA information that is in the CCADB (including Points of Contact), a hierarachy of root certiicates and intermediate certificates, and all cases, reports, and communications for your CA.
+**My CA**: Click on the 'My CA' tab to see your CA information in the CCADB (including Points of Contact), a hierarchy of root certificates and intermediate certificates, and all cases, reports, and communications for your CA.
 
 **CA Owners/Certificates**: Click on the 'CA Owners/Certificates' tab  (which may be under the 'More' tab) to see lists of certificates. 
 * Click on 'Recently Viewed' in the upper left corner. 


### PR DESCRIPTION
- Removed all instances of 'CA Communications' since 'Communications' is now a subsection under My CA. 
- Modified the 'My CA' description to include all of the subsections.
- Adjusted line formatting.