### PR TITLE
Add references to NetSec and S/MIME Audits

### DIFF
--- a/cas/ALV.md
+++ b/cas/ALV.md
@@ -34,14 +34,14 @@ The following fields are set by running ALV on an intermediate certificate recor
     * This field will be set to PASS when ALV finds the SHA-256 Fingerprint for that certificate in the BR audit statement. 
 * EV SSL Audit ALV Found Cert
     * This field will only be set when the [Derived Trust Bits](fields#formula-fields) field has "Server Authentication" in its list, and the [EV SSL Capable](fields#formula-fields) field is set to TRUE. 
-    * This field will be set to PASS when ALV finds the SHA-256 Fingerprint for that certificate in the EV SSL audit statement.
+    * This field will be set to PASS when ALV finds the SHA-256 Fingerprint for that certificate in the EV TLS audit statement.
 
 When ALV returns FAIL for "Standard Audit ALV Found Cert", "Code Signing Audit ALV Found Cert", "BR Audit ALV Found Cert", or "EV SSL Audit ALV Found Cert" for one of your CA's intermediate certificate records in the CCADB, do the following.
 
 * Check the corresponding audit statement to make sure the SHA-256 fingerprint of the certificate is correctly listed.
 * If the SHA-256 fingerprint is listed in the audit statement, then make sure that it meets the [format specifications](../policy#51-audit-statement-content), such as no colons, no spaces, no line feeds.
 * Have your auditor provide an updated audit statement that follows the [formatting requirements](../policy#51-audit-statement-content) for the SHA-256 Fingerprints.
-* If you do not agree with the ALV results, add comments to the "Standard Audit ALV Comments", "Code Signing Audit ALV Comments", "TLS BR Audit ALV Comments", or "EV SSL Audit ALV Comments" fields to indicate that the SHA-256 fingerprint is listed correctly in the audit statement.
+* If you do not agree with the ALV results, add comments to the "Standard Audit ALV Comments", "Code Signing Audit ALV Comments", "TLS BR Audit ALV Comments", or "TLS EVG Audit ALV Comments" fields to indicate that the SHA-256 fingerprint is listed correctly in the audit statement.
 * If the audit statement is indeed missing the SHA-256 fingerprint for the certificate, then file an [Incident Report](https://www.ccadb.org/cas/incident-report), and add the link to the Incident Report to one of the "...ALV Comments" fields.
 
 Important clarifications:

--- a/cas/ALV.md
+++ b/cas/ALV.md
@@ -10,8 +10,8 @@ Table of Contents:
 
 ## Root Certificates
 
-CA Owners are required to update the audit, CP, CPS and test website information for their certificate hierarchies at least annually. To provide this information for root certificates, create one [Add/Update Root Request Case](updates#audit-case-workflow) in the CCADB for a particular set of audits (e.g. Standard Audit, BR audit, EV SSL Audit, Code Signing Audit).
-* [Update audit, CP, CPS, and testwebsite information in the CCADB ](updates)
+CA Owners are required to update the audit, CP, CPS and test website information for their certificate hierarchies at least annually. To provide this information for root certificates, create one [Add/Update Root Request Case](updates#audit-case-workflow) in the CCADB for a particular set of audits (e.g. Standard Audit, TLS BR audit, EV TLS Audit, Code Signing Audit, S/MIME Audit).
+* [Update audit, CP, CPS, and test website information in the CCADB ](updates)
 
 ## Intermediate Certificates ##
 
@@ -25,7 +25,7 @@ CA Owners are required to annually update the audit and CP/CPS for their non-tec
 
 When the audit statements for an intermediate certificate are the same as the certificate that signed it, check the “Audits Same as Parent” checkbox instead of providing separate audit information. When the "Audits Same as Parent" field is checked for an intermediate certificate record, the CCADB will look up the parent chain until audit statements are found, and then run ALV using those audit statements. When the "Audits Same as Parent" field is not checked, the CCADB will directly pass the audit statements in the intermediate certificate record into ALV.
 
-The following fields are set by running ALV on an intermediate certificate record in the CCADB. CA Owners may cause ALV to be run on the record by clicking on the "Audit Letter Validation [ALV]" button. Additionally CCADB has automated processes that will regularly check for intermediate certificate records that need to have ALV run.
+The following fields are set by running ALV on an intermediate certificate record in the CCADB. CA Owners may cause ALV to be run on the record by clicking on the "Audit Letter Validation [ALV]" button. Additionally, CCADB has automated processes that will regularly check for intermediate certificate records that need to have ALV run.
 
 * Standard Audit ALV Found Cert
     * This field will be set to PASS when ALV finds the SHA-256 Fingerprint for that certificate in the standard audit statement.
@@ -41,7 +41,7 @@ When ALV returns FAIL for "Standard Audit ALV Found Cert", "Code Signing Audit A
 * Check the corresponding audit statement to make sure the SHA-256 fingerprint of the certificate is correctly listed.
 * If the SHA-256 fingerprint is listed in the audit statement, then make sure that it meets the [format specifications](../policy#51-audit-statement-content), such as no colons, no spaces, no line feeds.
 * Have your auditor provide an updated audit statement that follows the [formatting requirements](../policy#51-audit-statement-content) for the SHA-256 Fingerprints.
-* If you do not agree with the ALV results, add comments to the "Standard Audit ALV Comments", "Code Signing Audit ALV Comments", "BR Audit ALV Comments", or "EV SSL Audit ALV Comments" fields to indicate that the SHA-256 fingerprint is listed correctly in the audit statement.
+* If you do not agree with the ALV results, add comments to the "Standard Audit ALV Comments", "Code Signing Audit ALV Comments", "TLS BR Audit ALV Comments", or "EV SSL Audit ALV Comments" fields to indicate that the SHA-256 fingerprint is listed correctly in the audit statement.
 * If the audit statement is indeed missing the SHA-256 fingerprint for the certificate, then file an [Incident Report](https://www.ccadb.org/cas/incident-report), and add the link to the Incident Report to one of the "...ALV Comments" fields.
 
 Important clarifications:

--- a/cas/fields.md
+++ b/cas/fields.md
@@ -26,13 +26,14 @@ other fields in this section, then uncheck this box.</td>
 </tr>
 </table>
 <br>
-There are 5 audit statements that may be provided:
+There are 6 audit statements that may be provided:
 <ol>
 <li>Standard Audit</li>
+<li>Network Security Audit</li>
+<li>TLS Baseline Requirements Audit</li> 
+<li>TLS EV Guidelines Audit</li> 
 <li>Code Signing Audit</li>
-<li>BR Audit</li>
-<li>EV SSL Audit</li>
-<li>EV Code Signing Audit</li>
+<li>S/MIME Baseline Requirements Audit</li>
 </ol>
 For each applicable audit, the following information must be provided, and must meet 
 the individual Root Store requirements and the requirements of 
@@ -41,9 +42,10 @@ the individual Root Store requirements and the requirements of
 <tr valign="top"><th>Field Name</th><th>What to Enter</th></tr>
 
 <tr valign="top">
-<td>Audit</td>
+<td>Audit Statement (Link)</td>
 <td>URL to the audit statement PDF. <br>
 WebTrust Seals: Enter the WebTrust Seal URL into this field. When you save your changes, the CCADB will automatically convert the Seal URL to the URL of the corresponding audit statement PDF.
+ETSI Auditor's URL: Enter the URL that points to the Audit Attestation Letter (AAL) that is stored on your ETSI auditor's website.
 </td>
 </tr>
 <tr valign="top">

--- a/resources.md
+++ b/resources.md
@@ -12,7 +12,7 @@
   * [PEM of Root Certificates in Mozilla's Root Store with the Websites (TLS/SSL) Trust Bit Enabled (TXT)](https://ccadb.my.salesforce-sites.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites)
   * [PEM of Root Certificates in Mozilla's Root Store with the Websites (TLS/SSL) Trust Bit Enabled (CSV)](https://ccadb.my.salesforce-sites.com/mozilla/IncludedRootsDistrustTLSSSLPEMCSV?TrustBitsInclude=Websites)
 * [All Certificate Information (root and intermediate) in CCADB](https://ccadb.my.salesforce-sites.com/ccadb/AllCertificateRecordsCSVFormat) (CSV) (without NetSec and S/MIME audit information)
-* [Version 2 - All Certificate Information (root and intermediate) in CCADB](https://ccadb.my.salesforce-sites.com/ccadb/AllCertificateRecordsCSVFormatv2) (CSV) (with NetSec and S/MIME audit information)
+* **[NEW Version 2 - All Certificate Information (root and intermediate) in CCADB](https://ccadb.my.salesforce-sites.com/ccadb/AllCertificateRecordsCSVFormatv2) (CSV) (with NetSec and S/MIME audit information)**
 * [All Included Root Certificate Trust Bit Settings](https://ccadb.my.salesforce-sites.com/ccadb/AllIncludedRootCertsCSV) (CSV)
 * [List of CA problem reporting mechanisms (email, etc.)](https://ccadb.my.salesforce-sites.com/ccadb/AllProblemReportingMechanismsReport) (use this to report a certificate problem directly to the CA)
 * [List of CAA Identifiers](https://ccadb.my.salesforce-sites.com/ccadb/AllCAAIdentifiersReport) (used to restrict issuance of certificates to specific CAs via a [DNS Certification Authority Authorization Resource Record](https://tools.ietf.org/html/rfc6844))

--- a/resources.md
+++ b/resources.md
@@ -11,7 +11,8 @@
 * Server Authentication (SSL/TLS) Root Certificates
   * [PEM of Root Certificates in Mozilla's Root Store with the Websites (TLS/SSL) Trust Bit Enabled (TXT)](https://ccadb.my.salesforce-sites.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites)
   * [PEM of Root Certificates in Mozilla's Root Store with the Websites (TLS/SSL) Trust Bit Enabled (CSV)](https://ccadb.my.salesforce-sites.com/mozilla/IncludedRootsDistrustTLSSSLPEMCSV?TrustBitsInclude=Websites)
-* [All Certificate Information (root and intermediate) in CCADB](https://ccadb.my.salesforce-sites.com/ccadb/AllCertificateRecordsCSVFormat) (CSV)
+* [All Certificate Information (root and intermediate) in CCADB](https://ccadb.my.salesforce-sites.com/ccadb/AllCertificateRecordsCSVFormat) (CSV) (without NetSec and S/MIME audit information)
+* [Version 2 - All Certificate Information (root and intermediate) in CCADB](https://ccadb.my.salesforce-sites.com/ccadb/AllCertificateRecordsCSVFormatv2) (CSV) (with NetSec and S/MIME audit information)
 * [All Included Root Certificate Trust Bit Settings](https://ccadb.my.salesforce-sites.com/ccadb/AllIncludedRootCertsCSV) (CSV)
 * [List of CA problem reporting mechanisms (email, etc.)](https://ccadb.my.salesforce-sites.com/ccadb/AllProblemReportingMechanismsReport) (use this to report a certificate problem directly to the CA)
 * [List of CAA Identifiers](https://ccadb.my.salesforce-sites.com/ccadb/AllCAAIdentifiersReport) (used to restrict issuance of certificates to specific CAs via a [DNS Certification Authority Authorization Resource Record](https://tools.ietf.org/html/rfc6844))


### PR DESCRIPTION
This change modifies the CCADB website by referencing the new fields for NetSec and S/MIME audits.