### PR TITLE
update references to Mozilla

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,6 @@
-# Community Participation Guidelines
+# Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
-For more details, please read the
-[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
+This repository is governed by the [Code of Conduct (CCADB Members)](https://docs.google.com/document/d/1BeP7YJVJlRzXTwDm9r_VJhsuhQ_1tj0g7fDbdk6zk4k/edit?usp=sharing). 
 
 ## How to Report
-For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
-
-<!--
-## Project Specific Etiquette
-
-In some cases, there will be additional project etiquette i.e.: (https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
-Please update for your project.
--->
+To report violations of the Participation Guidelines, please send email to support [at] ccadb [dot] org.

--- a/rootstores/usage.md
+++ b/rootstores/usage.md
@@ -3,15 +3,14 @@
 ## CCADB Data Usage Terms ##
 
 Redistribution and use of this data is permitted provided that neither the name 
-and trademarks of Mozilla Corporation nor the names and trademarks of any 
-Common CA Database contributor may be used to endorse or promote products 
-derived from this data without specific prior written permission.
+and trademarks of the Common CA Database (CCADB) nor the names and trademarks of any 
+CCADB contributor may be used to endorse or promote products derived from this data.
 
-THIS DATA IS PROVIDED BY MOZILLA CORPORATION AND COMMON CA 
+THIS DATA IS PROVIDED BY COMMON CA 
 DATABASE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
 OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL MOZILLA CORPORATION AND COMMON 
+DISCLAIMED. IN NO EVENT SHALL COMMON 
 CA DATABASE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
 INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
@@ -22,65 +21,58 @@ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS DATA, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ## CCADB Root Store Operator Usage Terms ##
-As permitted by section 4 of the [Common CA Database
-Agreement](mozilla-ccadb-agreement.pdf), and in addition to any other requirements set out
-therein, Mozilla sets some usage terms and rules for Root Store Operators using
+As permitted by the [Bylaws of the CCADB](Bylaws.md), 
+and in addition to any other requirements set out 
+therein, the CCADB Steering Committee sets some usage terms and rules for using 
 the CCADB, as follows.
 
 ### Meetings ###
 
-Root Store Operators of the CCADB may meet by teleconference or
-at face-to-face meetings for the purpose of discussing improvements or changes
-to the operation of the CCADB. Such discussions should not include
-competitively-sensitive information. Mozilla shall not be responsible for the
-expenses of any such teleconferences or meetings.
+Root Store Operators (Members) of the CCADB may meet by teleconference or 
+at face-to-face meetings for the purpose of discussing improvements or changes 
+to the operation of the CCADB. Such discussions should not include 
+competitively-sensitive information. 
 
 ### Customizing the CCADB ###
 
-A Root Store Operator may make customization changes that only impact itself.
-Before being applied to the production instance of the CCADB,
-changes will be reviewed and tested by Mozilla (or its representative),
-including to ensure that the changes will not negatively impact any of the
-other Operators or the CCADB. Mozilla will either approve or decline
-the proposed changes. If the changes are approved, then a Mozilla
-representative will apply the changes to the production instance of the Common
-CA Database. If the changes are denied, then the Mozilla representative will
-provide an explanation, and the Operator organization may submit the
+A Root Store Operator (Member) may make customization changes that only impact itself. 
+Before being applied to the production instance of the CCADB, 
+changes will be reviewed and tested by the CCADB Steering Committee, 
+including to ensure that the changes will not negatively impact any of the 
+other Members or the CCADB. The CCADB Steering Committee will either approve or decline 
+the proposed changes. If the changes are approved, then the changes may be applied to the 
+production instance of the CCADB. If the changes are denied, then the 
+CCADB Steering Committee will 
+provide an explanation, and the Member may submit the 
 customizations again after addressing the feedback.
 
-Root Store Operators may request customization changes that impact shared data
-and interfaces. Mozilla (or its representative) will review, and approve or
-deny such requests. If the request is approved, Mozilla will prioritize the
-requested changes, and work with the Operators to design and test the changes in
-a sandbox environment before applying them to the production instance of the
+Members may request customization changes that impact shared data 
+and interfaces. The CCADB Steering Committee will review, and approve or 
+deny such requests. If the request is approved, the CCADB Steering Committee will prioritize the 
+requested changes, and work with the Members to design and test the changes in 
+a sandbox environment before applying them to the production instance of the 
 CCADB.
-
-The customizations that Mozilla has applied to the CCADB are
-available on [GitHub][CCADB-Github].
 
 ### Appropriate Data ###
 
-Root Store Operators may store the following types of data in the Common CA
-Database, as it pertains to the management of their Root Store Programs.
+The following types of data may be stored in the Common CA 
+Database, as it pertains to the management of Root Store Programs. 
 Aside from contact information, data uploaded to the Common CA Database is 
 made generally available to the public:
 
-* CA and subordinate CA certificate data;
+* CA certificate data;
 * CA Owner information (CA name, company website, physical address, etc.);
-* Contact information for CA Points of Contact (name, business email address, business phone number);
+* Contact information for CA Owner Points of Contact (name, business email address, business phone number);
 * Auditor information (Auditor name and location, auditor qualifications);
 * Contact information for Auditors (name, business email address, business phone number);
 * URLs to public-facing sites and documents;
 * URLs to internal-facing sites and documents (provided the URLs are not
   confidential);
 * Root-store-specific status and decisions regarding root inclusion/change
-  requests;
-* Dates and comments relating to root and intermediate certificates.
+  requests; and
+* Dates and comments relating to CA certificates.
 
-Root Store Operators shall **not** store the following types of data in the
-CCADB:
+Members shall **not** store the following types of data in the CCADB:
 
 * Confidential data
 * Personal (as opposed to business) contact information for individuals
-
-[CCADB-Github]:    https://github.com/CCADB

--- a/rootstores/why.md
+++ b/rootstores/why.md
@@ -3,57 +3,57 @@
 While maintaining an up-to-date root store containing only credible CAs is
 important and necessary for many organizations to help keep their end users
 safe, it is usually not done for profit and is not a strategic area for core
-business. Much of the data that Root Store Operators maintain for their
+business. Much of the data that Root Store Operators (Members) maintain for their
 programs is common and public data. Participating in the Common CA Database
 (CCADB) will pave the way for better, more efficient and more cost-effective
 management of your root store, making the internet safer for everyone.
 
 The CCADB has the following capabilities:
 
-* Automates notification to CA Owners when updated audit statements are due.
+* Automates notification to CA Owners when updated audit statements are due;
 * Enables multiple people to share in the maintenance of the CA Owner and CA certificate data
   (CP/CPS links, audit links/dates/auditor qualifications, Points of Contact,
-  etc.)
+  etc.);
 * Automates sending of communications to CA Owners and receiving and analyzing their
-  responses.
+  responses;
 * Makes it easier to review information and status associated with root
-  inclusion requests.
-* Tracks non-technically-constrained intermediate certificates.
-* Permits a CA Owner to apply to multiple root stores with a single request.
-* Makes your CA program more transparent.
+ inclusion requests;
+* Tracks non-technically-constrained intermediate certificates;
+* Permits a CA Owner to apply to multiple root stores with a single request; and
+* Makes your Root Store Program more transparent.
 
-Root Store Operators can:
 
-* Access the CCADB.
+Root Store Operators (Members) can:
+
+* Access the CCADB;
 * Independently operate and make decisions on root inclusion/change requests,
-  and verify audit data for their root stores.
-* Send email to all CA Owners in their program according to specified criteria.
-* Automate sending reminders to CA Owners about when periodic updates are due.
+  and verify audit data for their root stores;
+* Send email to all CA Owners in their program according to specified criteria;
+* Automate sending reminders to CA Owners about when periodic updates are due;
 * Share their findings in verifying data related to root and intermediate
-  certificates; including annual audits, policy documentation, contact
-  information, etc.
-* Make root-store-specific customizations to the CCADB (subject to Mozilla’s
-  approval).
+  certificates including annual audits, policy documentation, contact
+  information, etc.;
+* Make root-store-specific customizations to the CCADB (subject to CCADB Steering Committee
+  approval);
 * Propose and help design customizations to the CCADB that impact all
-  participants (subject to Mozilla’s approval).
-* Share in the cost of maintaining the CCADB.
-* Publish data relating to the root certificates included in their programs.
+  Members (subject to CCADB Steering Committee approval); and
+* Publish data relating to the CA certificates included in their programs.
+
 
 ## Cost ##
 
 The cost of operating and maintaining the CCADB is shared among
-the Root Store Operators. Mozilla’s goal in sharing the CCADB is to
+the Root Store Operators (Members). The goal in sharing the CCADB is to
 improve the quality of the CA data and help keep end users safe. It is
-expressly not a goal of Mozilla to make money from sharing the CCADB.
+expressly not a goal to make money from sharing the CCADB.
 
-Currently, the following types of costs are shared among Root Store Operators:
+Currently, the following types of costs are shared among Members:
 
 * Subscription fees and other costs imposed by the underlying CRM (e.g.,
-  Community and Enterprise license costs).
-* Costs of implementing shared customizations to the interface or data.
+  Community and Enterprise license costs);
+* Costs of implementing shared customizations to the interface or data; and
 * Maintenance costs.
 
 These categories of costs are subject to change.
 
-Interested in becoming a Root Store Operator in the CCADB? [See how](how).
-
+Interested in becoming a Root Store Operator (Member) in the CCADB? [See how](how).


### PR DESCRIPTION
Remove references to Mozilla from the CCADB website that become obsolete by moving the CCADB from Mozilla to the Linux Foundation CCADB Directed Fund.