### PR TITLE
[WIP] Update the CCADB Policy to Version 2.0

### DIFF
--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -228,7 +228,7 @@ While Full Incident Reports SHOULD be posted as soon as possible, they MUST be p
 
 CA Owners SHOULD respond promptly to comments and questions, and MUST respond within 7 days, even if only to acknowledge the request and provide a timeline for a full response.
 
-Unless a [Closure Report](#closure-report) has been posted, open incident reports MUST be updated:
+Unless a [Closure Report](#closure-report) has been posted and no further questions have been raised, open incident reports MUST be updated:
 - on or before the "Next update" date in the "Whiteboard" field of the bug (note: CA Owners MAY request the "Next update" Whiteboard field be set by a Root Store Operator to align with a specific date related to an open Action Item.);
 - within 7 days, if a "Next update" date is not recorded; or
 - when Action Items are changed, completed, or delayed.

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -241,7 +241,7 @@ In the case of Incident Reports with a Whiteboard field of "revocation-delay", r
 
 #### How are reports closed?
 
-When all Action Items are complete and no outstanding comments or questions remain, CA Owners MUST (1) request closure in a Bugzilla comment using the template [below](#incident-closure-summary) and (2) select the "Request information from" checkbox and add incident-reporting [at] ccadb [dot] org. Upon doing so, a final call for comments will be made by a Bugzilla moderator, and the report will be closed accordingly.
+When all Action Items are complete and no outstanding comments or questions remain, CA Owners MUST (1) request closure in a Bugzilla comment using the template [below](#incident-closure-summary) and (2) select the "Request information from" checkbox and add incident-reporting [at] ccadb [dot] org. Upon doing so, a final call for comments will be made by a Bugzilla moderator, and the report will be closed accordingly. After an Incident Closure Summary has been posted, CA Owners are not required to continue updating the incident report unless further questions are asked.
 
 ### Report Templates
 

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -4,7 +4,8 @@
 
 |Version|Effective Date|
 |-|-|
-|3.0 (current)|March 1, 2025| 
+|3.1 (current)|June  15, 2025| 
+|[3.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_3_0.md)|March 1, 2025| 
 |[2.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_2_0.md)|October 17, 2023| 
 |[1.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_1_0.md)|February 15, 2023|
 
@@ -36,6 +37,7 @@ Unless otherwise stated, "certificate" on this page refers to a final certificat
 
 [**Report lifecycle management**](#report-lifecycle-management)
 - [How do I submit a report?](#how-do-i-submit-a-report)
+- [How do I submit a security-sensitive incident report?](#how-do-i-submit-a-security-sensitive-incident-report)
 - [How are reports scoped?](#how-are-reports-scoped)
 - [What format is used?](#what-format-is-used)
 - [When are reports expected?](#when-are-reports-expected)
@@ -174,6 +176,18 @@ Create a new Bugzilla issue by filling out [this form](https://bugzilla.mozilla.
 - The "Summary" field in Bugzilla (i.e., "Subject line") MUST begin with the CA Owner’s name, followed by a colon, and a brief title that highlights the type of incident being reported (e.g., "EXAMPLE CA OWNER: Incorrect Subject RDN Encoding"). The CA Owner's name SHOULD match exactly with the CA Owner value in the CCADB.
 - The "Description" field MAY contain a Preliminary or Full Incident Report (copied and pasted from the corresponding Markdown template, as explained [below](#report-templates)).
 
+#### How do I submit a security-sensitive incident report?
+
+For additional context on what might be considered a "security-sensitive" incident, see [here](https://wiki.mozilla.org/CA/Vulnerability_Disclosure).
+
+Sensitive security incidents and vulnerabilities can be reported in Bugzilla by filling out [this form](https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&component=CA%20Security%20Vulnerability&groups=ca-program-security&product=CA%20Program). Under the heading "People", be sure to add incident-reporting [at] ccadb [dot] org to the report's CC list.
+
+_**Under the heading "Security", make sure that the "CA Program Security" checkbox is ticked -- leaving all security boxes unchecked makes it a public bug.**_
+
+After opening a security-sensitive incident in Bugzilla, also email incident-reporting [at] ccadb [dot] org.
+
+Following the submission of a security-sensitive incident in Bugzilla, the corresponding CA Owner MUST file a public incident report once they have determined that the associated security risk is closed.
+
 #### How are reports scoped?
 
 There SHOULD be a single Incident Report for each distinct matter, and CA Owners MUST submit an additional, separate Incident Report when:
@@ -228,7 +242,7 @@ In the case of Incident Reports with a Whiteboard field of "revocation-delay", r
 
 #### How are reports closed?
 
-When all Action Items are complete and no outstanding comments or questions remain, CA Owners MUST request closure in a Bugzilla comment using the template [below](#incident-closure-summary). Upon doing so, a final call for comments will be made by a Bugzilla moderator, and the report will be closed accordingly.
+When all Action Items are complete and no outstanding comments or questions remain, CA Owners MUST (1) request closure in a Bugzilla comment using the template [below](#incident-closure-summary) and (2) select the "Request information from" checkbox and add incident-reporting [at] ccadb [dot] org. Upon doing so, a final call for comments will be made by a Bugzilla moderator, and the report will be closed accordingly.
 
 ### Report Templates
 

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -233,7 +233,7 @@ CA Owners SHOULD respond promptly to comments and questions, and MUST respond wi
 Unless a [Closure Report](#closure-report) has been posted and no further questions have been raised, open incident reports MUST be updated:
 - on or before the "Next update" date in the "Whiteboard" field of the bug (note: CA Owners MAY request the "Next update" Whiteboard field be set by a Root Store Operator to align with a specific date related to an open Action Item.);
 - within 7 days, if a "Next update" date is not recorded; or
-- when Action Items are changed, completed, or delayed.
+- within 3 days of an Action Item being changed, completed, or delayed.
 
 In the case of Incident Reports with a Whiteboard field of "revocation-delay", reports SHOULD be updated every 3 days and MUST be updated no less frequently than every 7 days to describe a summary of: 
 - the number of certificates that have been revoked;

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -226,12 +226,11 @@ While Full Incident Reports SHOULD be posted as soon as possible, they MUST be p
 
 #### When are reports updated?
 
-CA Owners should respond promptly to comments and questions, and MUST respond within 7 days, even if only to acknowledge the request and provide a timeline for a full response.
+CA Owners SHOULD respond promptly to comments and questions, and MUST respond within 7 days, even if only to acknowledge the request and provide a timeline for a full response.
 
-Open reports MUST be updated:
+Unless a [Closure Report](#closure-report) has been posted, open incident reports MUST be updated:
 - on or before the "Next update" date in the "Whiteboard" field of the bug (note: CA Owners MAY request the "Next update" Whiteboard field be set by a Root Store Operator to align with a specific date related to an open Action Item.);
-- within 7 days, if a "Next update" date is not recorded;
-- in response to community questions or comments as described above; or
+- within 7 days, if a "Next update" date is not recorded; or
 - when Action Items are changed, completed, or delayed.
 
 In the case of Incident Reports with a Whiteboard field of "revocation-delay", reports SHOULD be updated every 3 days and MUST be updated no less frequently than every 7 days to describe a summary of: 

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -249,7 +249,7 @@ When all Action Items are complete and no outstanding comments or questions rema
 The following templates MUST be used when submitting incident reports or requesting report closures.
 - [Preliminary Incident Report Template](#preliminary-incident-report)
 - [Full Incident Report Template](#full-incident-report)
-- [Report Closure Template](#closure-report)
+- [Closure Report Template](#closure-report)
 
 CA Owners submitting reports MUST complete all applicable fields in the relevant template.  Fields that are not applicable MUST still be included and marked 'N/A'.
 

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -103,7 +103,7 @@ Reports are expected to:
 - describe the circumstances that prevented the problem(s) from being detected earlier;
 - describe a clear timeline of a CA Owner's actions while responding to and remediating an incident;
 - include a detailed and measurable explanation of actions taken or planned by the CA Owner that demonstrate a substantive commitment of how the CA Owner's systems, policies, and/or processes will be made more robust (i.e., demonstrate continuous improvement); and
-- share lessons learned that could be helpful to all CA Owners in building better systems policies, and/or processes.
+- share lessons learned that could be helpful to all CA Owners in building better systems, policies, and/or processes.
 
 #### What does Root Cause Analysis consider?
 

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -186,7 +186,9 @@ _**Under the heading "Security", make sure that the "CA Program Security" checkb
 
 After opening a security-sensitive incident in Bugzilla, also email incident-reporting [at] ccadb [dot] org.
 
-Following the submission of a security-sensitive incident in Bugzilla, the corresponding CA Owner MUST file a public incident report once they have determined that the associated security risk is closed.
+Following the submission of a security-sensitive incident in Bugzilla, and once the associated security risk is mitigated, the corresponding CA Owner MUST either: 
+- file a new public incident report for the event, or
+- send an email to incident-reporting [at] ccadb [dot] org and request the existing security-sensitive incident be converted to a public incident report.
 
 #### How are reports scoped?
 

--- a/cas/incident-report.md
+++ b/cas/incident-report.md
@@ -4,7 +4,7 @@
 
 |Version|Effective Date|
 |-|-|
-|3.1 (current)|June  15, 2025| 
+|3.1 (current)|July 15, 2025| 
 |[3.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_3_0.md)|March 1, 2025| 
 |[2.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_2_0.md)|October 17, 2023| 
 |[1.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_1_0.md)|February 15, 2023|

--- a/incident_archive/ir_version_3_0.md
+++ b/incident_archive/ir_version_3_0.md
@@ -1,0 +1,542 @@
+# Incident Reporting Guidelines
+
+## Change History
+
+|Version|Effective Date|
+|-|-|
+|3.0 (current)|March 1, 2025| 
+|[2.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_2_0.md)|October 17, 2023| 
+|[1.0](https://github.com/mozilla/www.ccadb.org/blob/master/incident_archive/ir_version_1_0.md)|February 15, 2023|
+
+## Incident Reporting
+
+Systems, processes, and people aren't perfect. Omissions and deviations from expected outcomes can sometimes happen. However, when omissions or deviations are discovered, the underlying issues (i.e., root causes) need to be identified and remediated to discourage future recurrence. Formally documenting these cases, in the form of an Incident Report, promotes a thorough understanding of contributing factors and facilitates clear communication of remediation plans, while also fostering a culture of continuous improvement within the Web PKI ecosystem.
+
+This page describes the CCADB Incident Reporting Framework and corresponding guidelines. For questions, contact support [at] ccadb [dot] org.
+
+### Definitions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" on this page are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+Unless otherwise stated, "certificate" on this page refers to a final certificate, distinct from a precertificate (as described in [RFC 6962](https://datatracker.ietf.org/doc/html/rfc6962)).
+
+## Table of Contents
+
+[**Useful background**](#useful-background)
+- [What is considered an incident?](#what-is-considered-an-incident)
+- [What is considered an audit finding?](#what-is-considered-an-audit-finding)
+- [Why is public reporting important?](#why-is-public-reporting-important)
+- [What are the key characteristics of these reports?](#what-are-the-key-characteristics-of-these-reports)
+- [What does root cause analysis consider?](#what-does-root-cause-analysis-consider)
+
+[**Community participation in the reporting process**](#community-participation-in-the-reporting-process)
+- [Who can submit an Incident Report?](#who-can-submit-an-incident-report)
+- [Are there other ways to become involved in the reporting process?](#are-there-other-ways-to-become-involved-in-the-reporting-process)
+- [What Bugzilla account can I use?](#what-bugzilla-account-can-i-use)
+
+[**Report lifecycle management**](#report-lifecycle-management)
+- [How do I submit a report?](#how-do-i-submit-a-report)
+- [How are reports scoped?](#how-are-reports-scoped)
+- [What format is used?](#what-format-is-used)
+- [When are reports expected?](#when-are-reports-expected)
+- [When are reports updated?](#when-are-reports-updated)
+- [How are reports closed?](#how-are-reports-closed)
+  
+[**Report templates**](#report-templates)
+- [Preliminary Incident Report Template](#preliminary-incident-report)
+- [Full Incident Report Template](#full-incident-report)
+- [Report Closure Template](#closure-report)
+
+[**Report field definitions and expectations**](#report-field-definitions-and-expectations)
+- [Incident Reports](#incident-reports)
+- [Incident Closure Summary](#incident-closure-summary)
+
+[**Illustrative practices**](#illustrative-practices)
+- [Are there examples of "good" practices?](#are-there-examples-of-good-practices)
+- [Are there examples of "bad" practices?](#are-there-examples-of-bad-practices)
+- [Are there examples of "good" reports?](#are-there-examples-of-good-reports)
+
+
+### Useful background
+
+#### What is considered an incident?
+
+Minimally, a failure to meet the commitments described in any of the following policies is considered an incident:
+- a CA Owner's own policies (e.g., CP, CPS, or combined CP/CPS);
+- applicable requirements promulgated by the CA/Browser Forum;
+- the CCADB Policy; or
+- any applicable Root Store Operator policy.
+
+Root Store Operator policies may further define what those individual programs consider incidents and/or outline additional incident reporting expectations.
+
+It's important to note that the existence of an Incident Report does not generally indicate serious problems with a CA. 
+
+For publicly-trusted CA Owners, the number of incident reports filed in Bugzilla is less important than the content and quality of those reports.
+
+#### What is considered an audit finding?
+
+Qualifications, non-conformities, and other deviations or omissions identified during audits are considered "findings."
+
+These items are commonly, but not exclusively, presented as either:
+- major non-conformities,
+- minor non-conformities,
+- qualifications,
+- qualified opinions, or
+- other matters.
+
+#### Why is public reporting important?
+
+Incident Reports provide lessons learned and transparency about the steps the CA Owner takes to address the immediate issue and prevent future issues. If the underlying problem goes unfixed, then other issues that share the same root cause will subsequently surface. 
+
+The public reporting process is important because it promotes continuous improvement, information sharing, and highlights opportunities to define and adopt improved practices, policies, and controls. Further, public reporting helps convey the implications and impact of an event so that affected stakeholders have an opportunity to assess risk and determine if it warrants further action. Together, these activities help build a more secure web. 
+
+#### What are the key characteristics of these reports?
+
+Reports are expected to:
+- be candid (i.e., focusing on honesty and forthrightness, even when revealing uncomfortable truths), timely (i.e., released without undue delay), and transparent (i.e., emphasizing open accessibility of information);
+- clearly (i.e., avoiding jargon, defining technical terms, adding useful background information) and objectively (i.e., supporting claims with data) communicate the scope, impact, and severity of an incident;
+- help community members understand the relevant architectures, implementations, operations, and external dependencies surrounding an incident;
+- demonstrate a detailed understanding of the root cause(s) of an incident;
+- unambiguously explain how systems, processes, and/or policies failed; 
+- describe the circumstances that prevented the problem(s) from being detected earlier;
+- describe a clear timeline of a CA Owner's actions while responding to and remediating an incident;
+- include a detailed and measurable explanation of actions taken or planned by the CA Owner that demonstrate a substantive commitment of how the CA Owner's systems, policies, and/or processes will be made more robust (i.e., demonstrate continuous improvement); and
+- share lessons learned that could be helpful to all CA Owners in building better systems policies, and/or processes.
+
+#### What does Root Cause Analysis consider?
+
+Effective Root Cause Analysis (RCA) minimally considers the following points:
+
+1. **Focus on the "why," not just the "what"**. RCAs go beyond identifying what went wrong and delve deeper into why it happened. This often involves looking past the immediate technical or policy failure and considers contributing factors like human error, process deficiencies, or system design flaws.
+
+2. **Use a systematic approach**. Employ structured methodologies like the following approaches to help ensure a thorough and organized investigation:
+   - [**Chesterton’s Fence**](https://fs.blog/chestertons-fence/): Before changing anything, understand why it's there. This helps avoid unintended consequences and ensures solutions address the root cause, not just symptoms.
+   - [**5 Whys**](https://en.wikipedia.org/wiki/Five_whys): Repeatedly ask "why" as many times as necessary to uncover the underlying cause of a problem. This simple technique helps drill down to the core issue and prevents superficial solutions.
+   - **Multi/Second Order Thinking** ([1](https://fs.blog/second-order-thinking/), [2](https://betterletter.substack.com/p/second-order-thinking), [3](https://medium.com/@noahmp/second-order-thinking-3fc2a224b131)): Think beyond immediate consequences. Consider the ripple effects of actions and potential downstream impacts to make more informed decisions.
+   - [**CATWOE**](https://www.toolshero.com/problem-solving/catwoe-analysis/): Analyze a problem from different perspectives (customers, actors, transformation, world view, owner, environmental constraints). This ensures a holistic understanding of the issue and its context.
+   - [**Cause and Effect / Fishbone or Ishikawa**](https://en.wikipedia.org/wiki/Ishikawa_diagram): Visually map potential causes of a problem, categorizing them to identify root causes and relationships. This promotes systematic exploration and prevents overlooking factors.
+   - [**Drilling Down**](https://sigma.software/about/media/problem-solving-techniques-part-two#2.-drill-down): Break complex problems into smaller, more manageable parts. This allows for focused investigation and helps identify specific areas for improvement.
+   - **SRE Handbook Guidance**: These chapters provide practical advice on managing incidents effectively, including communication, coordination, and postmortem analysis. They emphasize a blameless culture focused on learning and improvement.
+       - [Chapter 14](https://sre.google/sre-book/managing-incidents/)
+       - [Chapter 15](https://sre.google/sre-book/postmortem-culture/)
+
+4. **Consider all potential contributing factors**. RCAs consider a broad range of potential causes, including technical issues, policy issues, human factors, process breakdowns, and external influences. It's crucial to avoid jumping to conclusions or focusing solely on the most obvious cause(s).
+
+5. **Collect and analyze data**. Data is critical for supporting RCA conclusions and may include reviewing logs, monitoring metrics, internal incident reports, and other relevant information to identify patterns and anomalies.
+
+6. **Involve relevant stakeholders**. RCAs are a collaborative effort involving engineers, operators, support teams, and other relevant stakeholders to ensure a diverse range of perspectives and expertise is considered.
+
+7. **Prioritize action items**. The ultimate goal of an RCA is to prevent future incidents caused by the same failures; therefore, it's important to identify and prioritize actionable recommendations that address the identified root causes.
+
+8. **Focus on blameless postmortems**. Emphasize a blameless culture when conducting postmortems. The focus is on learning from the incident and improving systems, not on assigning blame or punishing individuals.
+
+9. **Continuously improve the process**. RCA is an iterative process where an organization continuously refines its approach based on lessons learned from previous incidents and evolving best practices.
+
+### Community participation in the reporting process
+
+#### Who can submit an Incident Report?
+
+Anyone should feel encouraged to submit an Incident Report that’s founded upon credible and well-substantiated evidence.
+
+Some Root Store Operator policies require CA Owners to submit an Incident Report as described on this page after self-discovering or being made aware of an Incident (e.g., receiving and corroborating an issue described in a [Certificate Problem Report](https://cabforum.org/working-groups/server/baseline-requirements/requirements/#161-definitions)).
+  
+#### Are there other ways to become involved in the reporting process?
+
+Absolutely! There are many ways to participate in the incident reporting process beyond submitting new reports. Everyone is encouraged to actively contribute by commenting on existing reports and engaging in constructive discussions. This can include, but is not limited to:
+- providing additional information,
+- asking clarifying questions,
+- discussing technical aspects of the incident,
+- suggesting corrective actions,
+- highlighting opportunities for improvement,
+- contributing lints to open source linting projects to promote improved future issue detection/prevention, and
+- sharing lessons learned from past experiences.
+
+Individuals representing CA Owners are especially encouraged to participate broadly in the reporting processes, extending their contributions beyond incidents involving only their own organization. Sharing insights and perspectives across organizational boundaries fosters a collaborative learning environment and strengthens the overall security posture of the Web PKI ecosystem.
+
+Please keep all comments constructive, relevant, and in line with the [CCADB Code of Conduct](https://docs.google.com/document/d/19ALqEvHtTE6OUTz2FaOXrU9gruIdvia5EDh3hXeGpZA/edit#heading=h.cumc0pgd1s7c) to ensure productive dialogue.
+
+#### What Bugzilla account can I use?
+
+**For individuals affiliated with a Publicly-Trusted CA Owner:**
+- **To better encourage blamelessness**, when posting incident reports or responding to comments on reports for which they are affiliated, participants MAY respond from a Bugzilla account associated with one of the CA e-mail aliases disclosed to the CCADB, rather than an individual contributor’s account.
+- **To better respect a desire for individual privacy and potential risk of retaliation**, individuals participating in the reporting process MAY participate **responsibly** from an account that does not identify the individual posting or their organizational affiliation.
+
+**For everyone else:** Create a new Bugzilla account following [these](https://bugzilla.mozilla.org/createaccount.cgi) instructions. 
+
+**Remember**, please keep all comments constructive, relevant to the corresponding report, and in line with the [CCADB Code of Conduct](https://docs.google.com/document/d/19ALqEvHtTE6OUTz2FaOXrU9gruIdvia5EDh3hXeGpZA/edit#heading=h.cumc0pgd1s7c).
+
+### Report lifecycle management
+
+#### How do I submit a report?
+
+Create a new Bugzilla issue by filling out [this form](https://bugzilla.mozilla.org/enter_bug.cgi?format=__default__&product=CA%20Program&component=CA%20Certificate%20Compliance&bug_type=task). 
+
+- The "Summary" field in Bugzilla (i.e., "Subject line") MUST begin with the CA Owner’s name, followed by a colon, and a brief title that highlights the type of incident being reported (e.g., "EXAMPLE CA OWNER: Incorrect Subject RDN Encoding"). The CA Owner's name SHOULD match exactly with the CA Owner value in the CCADB.
+- The "Description" field MAY contain a Preliminary or Full Incident Report (copied and pasted from the corresponding Markdown template, as explained [below](#report-templates)).
+
+#### How are reports scoped?
+
+There SHOULD be a single Incident Report for each distinct matter, and CA Owners MUST submit an additional, separate Incident Report when:
+- policy requires the revocation of one or more certificates by a certain deadline, such as those in BR Section 4.9, but that deadline will not be or has not been met by the CA Owner (i.e., a delayed revocation Incident Report).
+- in the process of researching one incident, another incident with a distinct root cause and/or remediation is discovered.
+- after an incident is marked resolved in Bugzilla, the incident reoccurs.
+
+All reports MUST be free-standing and not rely on the contents of other reports.  While reports MAY repeat information from discussions or Bugzilla comments, they SHOULD summarize previous findings.  CA Owners are responsible for compiling a complete report according to these guidelines, even if information exists elsewhere.
+
+#### What format is used?
+
+Use one of the templates below, depending on the type of report being disclosed:
+
+- [Preliminary Incident Report](#preliminary-incident-report) (for third party reporters and CA Owners submitting Preliminary Incident Reports)
+- [Full Incident Report](#full-incident-report) (for CA Owners submitting Full Incident Reports)
+
+Report content MUST be provided in Markdown (i.e., not in the form of an attachment) and SHOULD utilize Markdown's [formatting features](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) (headers, lists, emphasis, etc.) to ensure clarity and readability. Individuals submitting reports SHOULD use Bugzilla's "preview" feature to confirm rendering appears as expected before posting.
+
+Learn more about expected report content and a description of the fields included in the reporting templates [here](#report-field-definitions-and-expectations).
+
+#### When are reports expected?
+
+Within 72 hours of a CA Owner becoming aware of an incident (i.e., the "initial incident disclosure") or an audit finding not previously disclosed in an Incident Report, the CA Owner MUST either:
+
+- disclose a Preliminary or Full Incident Report; or
+- respond to a Preliminary Incident Report previously created for the incident by a third party reporter.
+
+In its initial report (i.e, Preliminary or Full Incident Report) or reply to a third-party report, the CA Owner MUST:
+
+- accurately disclose the impact of the incident (e.g., the corpus of then-known mis-issued certificates); and
+- describe whether the incident should be considered contained (e.g., because certificate issuance was stopped) or ongoing.
+
+If the described impact of the incident is later found to be inaccurate, the CA Owner MUST clearly communicate a correction, identifying when each following change was detected, the circumstances that led to the inaccuracy, and how this will be avoided in the future.
+
+While Full Incident Reports SHOULD be posted as soon as possible, they MUST be posted within 14 days of the incident’s initial disclosure.
+
+#### When are reports updated?
+
+CA Owners should respond promptly to comments and questions, and MUST respond within 7 days, even if only to acknowledge the request and provide a timeline for a full response.
+
+Open reports MUST be updated:
+- on or before the "Next update" date in the "Whiteboard" field of the bug (note: CA Owners MAY request the "Next update" Whiteboard field be set by a Root Store Operator to align with a specific date related to an open Action Item.);
+- within 7 days, if a "Next update" date is not recorded;
+- in response to community questions or comments as described above; or
+- when Action Items are changed, completed, or delayed.
+
+In the case of Incident Reports with a Whiteboard field of "revocation-delay", reports SHOULD be updated every 3 days and MUST be updated no less frequently than every 7 days to describe a summary of: 
+- the number of certificates that have been revoked;
+- the number of certificates that have not yet been revoked;
+- the number of certificates planned for revocation that have expired; and
+- an estimate for when all remaining revocations will be completed.
+
+#### How are reports closed?
+
+When all Action Items are complete and no outstanding comments or questions remain, CA Owners MUST request closure in a Bugzilla comment using the template [below](#incident-closure-summary). Upon doing so, a final call for comments will be made by a Bugzilla moderator, and the report will be closed accordingly.
+
+### Report Templates
+
+The following templates MUST be used when submitting incident reports or requesting report closures.
+- [Preliminary Incident Report Template](#preliminary-incident-report)
+- [Full Incident Report Template](#full-incident-report)
+- [Report Closure Template](#closure-report)
+
+CA Owners submitting reports MUST complete all applicable fields in the relevant template.  Fields that are not applicable MUST still be included and marked 'N/A'.
+
+Learn more about expected report content and a description of the fields included in the templates [below](#incident-report-field-definitions-and-expectations).
+
+#### Preliminary Incident Report
+
+```markdown
+## Preliminary Incident Report
+
+### Summary
+- **Incident description:**
+- **Relevant policies:** 
+- **Source of incident disclosure:** 
+
+```
+
+#### Full Incident Report
+
+```markdown
+## Full Incident Report
+
+### Summary
+
+- **CA Owner CCADB unique ID:** 
+- **Incident description:** 
+- **Timeline summary:**
+   - **Non-compliance start date:** 
+   - **Non-compliance identified date:** 
+   - **Non-compliance end date:** 
+- **Relevant policies:** 
+- **Source of incident disclosure:** 
+
+### Impact
+
+- **Total number of certificates:**
+- **Total number of "remaining valid" certificates:** 
+- **Affected certificate types:** 
+- **Incident heuristic:** 
+- **Was issuance stopped in response to this incident, and why or why not?:** 
+- **Analysis:** 
+- **Additional considerations:** 
+
+### Timeline
+
+### Related Incidents
+
+| Bug                                | Date                        | Description                                                            |
+|------------------------------------|-----------------------------|------------------------------------------------------------------------|
+| [Related Bug ID](Related Bug URL)  | Date Related Bug was opened | A description of how the subject Bug is related to the Bug referenced. |
+
+### Root Cause Analysis
+
+**Contributing Factor #: title**
+- **Description:** 
+- **Timeline:** 
+- **Detection:** 
+- **Interaction with other factors:** 
+- **Root Cause Analysis methodology used:**
+
+### Lessons Learned
+
+- **What went well:** 
+- **What didn’t go well:** 
+- **Where we got lucky:** 
+- **Additional:** 
+
+### Action Items
+
+| Action Item | Kind    | Corresponding Root Cause(s) | Evaluation Criteria | Due Date   | Status |
+| ----------- | ----    | --------------------------- | ------------------- | -----------| ------ |
+| Example     | Prevent | Root Cause # 1              | Criteria            | 2025-01-19 | Value  |
+
+### Appendix
+
+```
+
+#### Closure Report
+
+```markdown
+
+### Report Closure Summary
+
+- **Incident description:** 
+- **Incident Root Cause(s):**  
+- **Remediation description:**
+- **Commitment summary:**  
+
+All Action Items disclosed in this report have been completed as described, and we request its closure.
+
+```
+
+### Report field definitions and expectations
+
+The following sections are intended to describe expected Incident Report content. All fields are mandatory for the corresponding report type, except when described below.
+
+If submitted by the CA Owner corresponding with the report, all fields included in the relevant template MUST be completed. Fields that are not applicable MUST be included in the report and identified as 'N/A'.
+
+#### Incident Reports
+
+**Summary:** The Summary section contains a short description of the nature of the issue and useful background information. This provides just enough context for readers to understand the details in the rest of the report. 
+
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **CA Owner CCADB unique ID*** | The CCADB unique ID value (begins with "A" followed by a six-digit number) corresponding to the CA Owner's "CA Owner/Certificate" record disclosed in the CCADB.  |
+| **Incident description** | A short description of the nature of the issue. This provides just enough context for new readers to understand the details of the incident. |
+| **Timeline summary*** | Describe (1) when the non-compliance began (2), when the non-compliance was detected, and (3) when the non-compliance ended or is expected to end. |
+| **Relevant policies** | Describe the policy name(s), applicable version(s), and corresponding section(s) that result in this problem being diagnosed as an incident. |
+| **Source of incident disclosure*** | Choice of "Self Reported", "Third Party Reported", or "Audit". |
+
+*Note*: If notified of an incident by an external, third party reporter, please respect their privacy by *only* disclosing their name if affirmatively approved to do so (e.g., say "we received a report from a community member" instead of explicitly naming individuals). Fields marked with an asterisk (*) are not required in Preliminary Incident Reports if submitted by a third party reporter.
+
+**Impact:** The Impact section contains a description of the size and nature of the incident. For example: how many certificates, OCSP responses, or CRLs were affected; whether the affected objects share features (such as issuance time, signature algorithm, or validation type); and whether the CA Owner had to cease issuance during the incident. 
+
+If certificates are impacted, the Impact section MUST include the following information:  
+
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **Total number of certificates** | The total count of all certificates affected by the issue(s) described in this Incident Report, including expired and revoked certificates. |
+| **Total number of "remaining valid" certificates** | The total count of certificates affected by the issue(s) described in this Incident Report, minus expired and revoked certificates. Minimally, this set of certificates MUST be disclosed in the Appendix section of this report. |
+| **Affected certificate types** |  A summary of the corresponding CA/Browser Forum policy OIDs (i.e., DV, IV, OV, and EV) that appear in the certificates affected by this incident (e.g., "This incident affects DV and OV certificates.”) |
+| **Incident heuristic** | **EITHER:** <br><br>**(1)** describe a heuristic that would allow a third party to assemble the full corpus of affected certificates, if not provided in the Appendix (e.g., "Any certificate containing policy OID 1.2.3.4.5.6 and issued between 11/13/2024 and 4/11/2024 is affected by this incident. Certificates that have been revoked or are expired are omitted from the certificate list disclosed in the Appendix.") <br><br> **(2)** clearly explain why this isn't possible (e.g., "This incident affected every certificate issued between 5/25/2023 and 6/15/2024 that relied upon BR Validation Method 3.2.2.4.19. Because the relied upon validation method is not described in a certificate, this heuristic cannot be used by a third party to assemble the full corpus of affected certificates. Certificates that have been revoked or expired have been omitted from the certificate list disclosed in the Appendix.), or <br><br> **(3)** the full corpus of affected certificates are disclosed in the Appendix.|
+| **Was issuance stopped in response to this incident, and why or why not?** | Yes/No with explanation (e.g., "Yes. As described in the incident timeline, issuance was stopped after learning of this issue to correct the corresponding certificate profile.") |
+| **Analysis** | Required when the Whiteboard field contains ‘revocation-delay’, the factors and rationales behind the decision to delay revocation (including detailed and substantiated explanations of how extensive harm would result to third parties–such as essential public services or widely relied-upon systems–and why the situation is exceptionally rare and unavoidable). |
+| **Additional considerations** | This field is optional. Share any additional considerations that might be useful in describing the size and nature of the incident. For example, if the issue affected precertificates and certificates differently, describe how and why in more detail here. |
+
+**Timeline:** The Timeline section includes a detailed timeline of all events and actions leading up to and taken during and after the incident. The timeline MUST include not just the actual discovery of the incident and subsequent events, but also relevant events occurring beforehand (e.g., something changed or was introduced). All times MUST be in UTC or UTC+local offset, and SHOULD have at least minute-level granularity.
+
+Expected Timeline elements:
+- All policy, process, and software changes that contributed to the Root Cause(s)
+- The time at which the incident began
+- The time at which the CA Owner became aware of the incident
+- The time at which the CA Owner received a Certificate Problem Report (if applicable)
+- The time at which the CA Owner provided a preliminary report on its findings to the entity who filed the Certificate Problem Report (if applicable)
+- The time at which the CA Owner provided a preliminary report on its findings to the affected Subscriber(s) (if applicable)
+- The time at which the CA Owner concluded and disclosed the scope and impact of the incident
+- The time at which the CA Owner updated the scope and impact of the incident (if applicable)
+- The time(s) at which the CA Owner is expected to complete revocation of affected certificates (if applicable, but required when Whiteboard field contains ‘revocation-delay’)
+- The time(s) at which the CA Owner actually completed revocation of affected certificates (if applicable, but required when Whiteboard field contains ‘revocation-delay’)
+- The time at which the incident ended
+- The times at which issuance ceased and resumed (if applicable)
+
+**Related Incidents:** The Related Incidents section includes a list of all incidents disclosed to the ['CA Certificate Compliance' Bugzilla Component](https://bugzilla.mozilla.org/buglist.cgi?product=CA%20Program&component=CA%20Certificate%20Compliance&resolution=---) related to this incident that have taken place minimally in the last two (2) years. "Related Incidents" MUST consider incidents beyond those corresponding to the CA Owner subject of this report.
+
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **Related Bug ID** | The Bugzilla ID corresponding to the related incident. |
+| **Related Bug URL** | The Bugzilla URL corresponding to the related incident. |
+| **Opened date** | The date the related incident was opened. |
+| **Description** | A description of how the related incident is similar to the subject incident report. |
+
+**Root Causes:** The Root Causes section contains a detailed analysis of the conditions which combined to give rise to the issue. It is unusual for an incident to have a single root cause; often there is a confluence of several issues such as a software bug, insufficient checks, and a malformed request. Make sure that all contributing factors are identified and described, including noting when they first arose and how they avoided detection until they were discovered or identified.
+
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **Description** | Describe the specific condition, event, or issue that contributed to the incident. Analyze its role in the incident's development. Consider when this factor first arose and its initial impact.  |
+| **Timeline** | Trace the timeline of the contributing factor from its inception to its role in the incident. When was it introduced or created? How did it evolve over time? |
+| **Detection** | Describe how the contributing factor was detected, and explain how it avoided detection prior to the incident. Were there inadequate safeguards, missed signals, or other factors that allowed it to persist? |
+| **Interaction with other factors** | Analyze how the contributing factor interacted with other identified factors to create the conditions for the incident. Did it amplify other issues or create new vulnerabilities? |
+| **Root Cause Analysis methodology used** | This field is optional, but recommended. A description of the methodology used to derive the issue described above (e.g., "5-Whys", Fishbone Diagram, Pareto Analysis, etc.) |
+
+**Lessons Learned:** The Lessons Learned section describes what the organization learned from the incident, including what they did well and what they need to improve.
+
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **What went well?** | A list of things that caused the incident to have less impact than it otherwise could have, such as early detection, rapid response, or good safety mechanisms. This section provides an opportunity for others to learn from the good practices of this CA Owner. |
+| **What didn’t go well?** | A list of things that caused the incident to have more impact than it otherwise would have, such as missing checks or unclear documentation. Each item here MUST have at least one corresponding Action Item below and SHOULD provide opportunities for others to ensure they make similar improvements if they haven’t already. |
+| **Where we got lucky?** | A list of things that went well, but which cannot be relied upon, such as early detection by an external security researcher or limited impact simply due to a small number of requests. Items here SHOULD generally also have corresponding Action Items, so that the CA Owner doesn’t have to rely on luck in the future. |
+| **Other** | Any other type of "lesson learned" that does not otherwise fit in the above categories, e.g., internal/external circumstances or environmental conditions; discovery of problematic processes, policies, or workflows; communication gaps; resource challenges; task ownership; overlooked warning signs; underutilized tools; etc. Each item mentioned here MUST have at least one corresponding Action Item. |
+
+**Action Items:** The Action Items section contains a list of remediation items that will be undertaken to ensure that similar incidents do not reoccur in the future. For example, if the Whiteboard field contains ‘revocation-delay’, the Action Items list MUST include steps reasonably calculated to prevent or reduce future revocation delays. Note that it is not sufficient for these action items to simply stop this incident, they MUST create additional protections to prevent future incidents.
+  
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **Action Item description** | A detailed description of the action to be taken. |
+| **Kind** | A classification of whether the action will help *Prevent* future incidents, *Mitigate* the impact of future incidents, or *Detect* future incidents. CA Owners are encouraged to propose action items in all three categories, with an emphasis on Prevent and Mitigate. |
+| **Corresponding Root Cause(s)** | The specific Root Cause that the Action intends to remediate (i.e., each problem/issue identified in the "Root Cause Analysis" and "What didn't go well" Sections MUST be mapped to at least one specific action item). |
+| **Evaluation criteria** | Describe how the CA Owner will measure the effectiveness of the Action Item in addressing the Root Cause. Include how the public can also measure this impact, if applicable. CA Owners SHOULD prioritize objective and publicly measurable evidence (i.e., evidence that can be independently verified by the public, such as through Certificate Transparency log data, audit statements, CA policy documents, and public communications (e.g., website content, surveys, etc.)). While external metrics are preferred, these Guidelines recognize that some Action Items may have limited measurable outcomes. When objective metrics are not readily available, CA Owners SHOULD provide a qualitative assessment of the Action Item's effectiveness and explain how they will monitor its impact. Even after an Incident Report has been closed, CA Owners are strongly encouraged to provide periodic updates (e.g., 3, 6, and 12 months post-closure, or at other determined appropriate intervals) related to the ongoing efficacy of the Action Item, as measured against the evaluation criteria. This helps demonstrate a continued commitment to improvement and transparency.
+| **Due date** | A date by which the action item will be complete. |
+| **Status** | Describe the status of the action item using either "Ongoing", "Complete", "Delayed", or "Canceled". |
+
+**Appendix:** The Appendix section is for all supporting data: log files, graphs and charts, etc. In the case of incidents that directly impact certificates (i.e., not only precertificates), the Appendix MUST disclose details related to the time-valid, including revoked, certificates affected by the incident.
+
+For incidents affecting less than 10,000 certificates, a CA Owner MUST attach a comma separated listing of certificate details including the following fields for each:
+
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **Precertificate SHA-256 hash** | The SHA-256 hash of the DER encoded precertificate. |
+| **Certificate SHA-256 hash** | The SHA-256 hash of the DER encoded certificate. |
+| **Subject** | The Subject field of the certificate. |
+| **Issuer** | The Issuer field of the certificate. |
+| **Not before** | The notBefore field of the certificate. |
+| **Not after** | The notAfter field of the certificate. |
+| **Serial #** | The Serial Number field of the certificate, in hex. |
+| **dNSNames** | The dNSName appearing in the certificate. |
+| **Is revoked?** | "Yes", "Planned","Delayed", or "N/A" (for expired) |
+| **Revocation date** | Actual Date, Planned Date, or "N/A" |
+| **Revocation reason** | The reasonCode corresponding with the certificate's entry on the CRL. |
+
+For incidents affecting 10,000 or more certificates, a CA Owner MAY instead attach a text file where each line is of the form https://crt.sh/?sha256=[sha256 fingerprint of the certificate].
+
+When the incident being reported involves an S/MIME certificate, if disclosure of personally identifiable information in the certificate MAY be contrary to applicable law, please provide at least the certificate serial number and SHA256 hash of the certificate.
+
+##### Incident Closure Summary
+
+The Incident Closure Summary allows a CA Owner to signal they believe an incident is ready for closure.
+
+| Field                           | Description                              |  
+|---------------------------------|------------------------------------------| 
+| **Incident description** | A few sentences summarizing the incident. |
+| **Incident Root Cause(s)** | A few sentences summarizing the root cause(s). |
+| **Remediation description** | A few sentences summarizing the incident's remediation. |
+| **Commitment summary** | A list of any ongoing commitments made in response to this incident beyond those described in the Action Items section. Ongoing commitments can be a useful representation of a CA Owner's continuous improvement efforts and should be considered distinct from, but complementary to Action Items included in the report given a broader scope and long-term or continuous timeframe that would otherwise result in the subject incident report being open for an extended period of time. |
+
+### Illustrative practices
+
+#### Are there examples of "good" practices?
+
+1. **Be detailed and precise**:
+   - Document, in detail, all findings and steps taken from discovery or initial notification through to remediation.
+   - Include precise timestamps, technical data, and decision rationales.
+   - Share relevant configurations, code snippets, or settings that were implicated, in compliance with security norms (i.e., do not disclose confidential or sensitive information).
+
+2. **Respond promptly**:
+   - Acknowledge receipt of the incident report quickly.
+   - Provide initial assessments and expected timelines for resolution to keep stakeholders informed.
+   - Respond to comments or questions within one business day.
+  
+3. **Be candid, transparent, and objective**:
+   - Doing so allows community members to better understand report content, while also promoting integrity and transparency.
+
+4. **Rely on comprehensive Root Cause Analysis frameworks**:
+   - Use structured methodologies like the "Five Whys" or fault tree analysis to trace back to underlying issues.
+   - Involve diverse teams (security, operations, engineering) to ensure a multi-faceted evaluation.
+
+5. **Be proactive and thorough**:
+   - Implement immediate fixes to mitigate any ongoing risks.
+   - Develop long-term solutions that might involve architectural changes or the integration of new security tools and practices.
+
+6. **Engage with the community**:
+   - Participate in Web PKI forums and email distributions (e.g., public@ccadb.org) to both learn from and contribute to community knowledge.
+   - Share incident learnings in a way that respects confidentiality but helps other organizations prevent similar issues.
+   - Read and adopt best practices found in the [Bugzilla Incident Reports filed by other CA Owners](https://bugzilla.mozilla.org/buglist.cgi?product=CA%20Program&component=CA%20Certificate%20Compliance&bug_status=__open__&list_id=17075089).
+
+7. **Share iterative updates**:
+   - Provide an initial response, followed by regular updates aligned with ["When should Incident Reports be updated?"](#when-should-incident-reports-be-updated) as new information becomes available or as fixes are deployed..
+   - Close the loop with a final summary once the issue is fully resolved, detailing the lessons learned and future prevention strategies.
+  
+8. **Respect external reporter privacy**:
+   - If notified of an incident by an external, third party reporter, please respect their privacy by *only* disclosing their name if affirmatively approved to do so (e.g. say "we received a report from a community member" instead of explicitly naming individuals).
+  
+9. **Use Markdown formatting**:
+   - Markdown formatting (e.g., headers, lists, bolding, italics, etc.) can promote clarity, readability, and accessability. Learn more about Markdown formatting [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+
+#### Are there examples of "bad" practices?
+
+1. **Generic or evasive responses**:
+   - Avoid generic statements that do not address specific issues raised in the report or in response to community questions or comments.
+   - Refrain from providing non-committal or ambiguous answers that might be interpreted as evasive.
+
+2. **Posturing**:
+   - Avoid blaming others or external factors.
+   - Resist downplaying the severity or implications of the incident.
+
+3. **Claims that are subjective, unqualified opinions, speculative, or impossible to substantiate**:
+   - Avoid making claims that are speculative or that cannot be corroborated (e.g. "there is no security impact due to this issue.")
+
+4. **Non-acknowledgment of responsibility**:
+   - Clearly accept responsibility where and when due, which helps in rebuilding trust and demonstrating accountability.
+
+5. **Superficial Root Cause Analysis**:
+   - Avoid superficial analyses that do not thoroughly explore all contributing factors.
+   - Ensure that the analysis is not prematurely concluded, missing deeper systemic issues.
+
+6. **Committing to opaque actions**:
+   - Ensure actions and follow-up work items are detailed and specific.
+   - Promote accountability by describing how the success of an action item can be evaluated as having been successful in addressing the root cause.
+
+7. **Inadequate monitoring post-report**:
+   - Establish mechanisms to monitor the long-term effectiveness of implemented changes.
+   - Be ready to revisit and revise solutions if subsequent issues indicate that the initial response was not entirely effective.
+  
+#### Are there examples of "good" reports?
+
+Here are some examples of good practice, where a CA Owner did most or all of the things recommended above:
+
+- [Serving invalid or incomplete CRLs](https://bugzilla.mozilla.org/show_bug.cgi?id=1900129)
+     - Clear Summary and Impact statements allow readers to quickly understand the scope of the incident
+     - Detailed and thorough evaluation of existing safeguards that failed, allowing for an understanding of why the the incident was allowed to take place
+     - Comments and questions from the community were responded to promptly.
+
+- [keyCompromise key blocking deviation from CP/CPS](https://bugzilla.mozilla.org/show_bug.cgi?id=1886876)
+     - Clear indication of Preliminary and Full Incident Reports.
+     - Detailed timeline that identifies all policy, process, and software changes that contributed to the root cause, and an indication of when the incident began and ended.
+     - Detailed Root Cause Analysis that offers background on the various conditions that gave rise to the issue.
+     - Timely updates in response to questions posed, continued analysis, and changes to Action Items.
+ 
+- [Failure to properly validate IP address](https://bugzilla.mozilla.org/show_bug.cgi?id=1876593)
+     - Significant amount of background information that informs the timeline of the incident.
+     - Clear identification of the contributing factors that contributed to the incident that notes how many of them avoided detection in the Root Cause Analysis.
+     - Action Items that prevent, mitigate, and detect what didn’t go well.
+     - Timely and detailed updates conveying Action Item status.
+
+Upon adoption of the updated report templates described on this page, examples of good practice will be updated.

--- a/policy.md
+++ b/policy.md
@@ -1,133 +1,232 @@
-# CCADB Policy #
+# CCADB Policy
 
-*Version 1.3.1, Effective: October 29, 2024*
+*Version 2.0, Effective: June 15, 2025*
 
 ## Introduction
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this policy are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
-Several Web PKI root store operators ("Stores") have collaborated to create the Common Certification Authority Database (CCADB), a data repository of certificate and Certification Authority (CA) information. CA Owners who wish to be included in participating Stores will need to maintain certain information in the CCADB. This document explains what is required of CA Owners who are required by Store policy to use the CCADB.
+Several Public Root Store Operators have collaborated to create the Common Certification Authority Database (CCADB), a data repository of certificate and Certification Authority (CA) information. 
 
-Stores MAY have their own additional CCADB-related requirements. For each root certificate, CA Owners MUST comply with the additional requirements pertaining to the Stores which contain that certificate. Additional information on Store requirements can be found [here](https://www.ccadb.org/resources).
+CA Owners who wish to be included in a CCADB-participating Root Store ("Root Store") need to disclose and maintain certain information in the CCADB. This policy describes common Root Store Operator requirements related to CA Owner use of the CCADB. This policy does not cover how to obtain write access to the CCADB or how to use the CCADB’s web interface. Additional information covering these topics is available [here](https://www.ccadb.org/cas/).
 
-This policy does not cover how to obtain write access to the CCADB or how to use the CCADB’s web interface. Additional information covering these topics is available [here](https://www.ccadb.org/cas/).
+Root Store Operators MAY have additional CCADB-related requirements defined in their own Root Store policies. These policies MAY strengthen the requirements described in this policy. Additional information on the policies belonging to the individual Root Store Operators participating in the CCADB can be found [here](https://www.ccadb.org/resources). Questions related to an individual Root Store Operator Policy SHOULD be directed to the operator of that policy using the contact address designated for that policy.
 
 ## Change History
 
 |Version|Effective Date|
 |-|-|
-|[1.0](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0.md)|May 23, 2017|
-|[1.0.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_1.md)|May 3, 2018|
-|[1.0.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_2.md)|May 3, 2018|
-|[1.0.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_3.md)|May 3, 2018|
-|[1.0.4](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_4.md)|July 16, 2018|
-|[1.0.5](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_5.md)|September 17, 2018|
-|[1.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_1.md)|December 6, 2021|
-|[1.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2.md)|February 15, 2023|
-|[1.2.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_1.md)|February 17, 2023|
-|[1.2.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_2.md)|May 11, 2023|
-|[1.2.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_3.md)|July 19, 2023|
+|2.0 (current)|June 15, 2025|
+|[1.3.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_3_1.md)|October 29, 2024|
 |[1.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_3.md)|October 25, 2023|
-|1.3.1 (current)|October 29, 2024|
+|[1.2.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_3.md)|July 19, 2023|
+|[1.2.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_2.md)|May 11, 2023|
+|[1.2.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_1.md)|February 17, 2023|
+|[1.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2.md)|February 15, 2023|
+|[1.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_1.md)|December 6, 2021|
+|[1.0.5](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_5.md)|September 17, 2018|
+|[1.0.4](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_4.md)|July 16, 2018|
+|[1.0.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_3.md)|May 3, 2018|
+|[1.0.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_2.md)|May 3, 2018|
+|[1.0.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_1.md)|May 3, 2018|
+|[1.0](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0.md)|May 23, 2017|
 
 <br>
 
+## Definitions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this policy are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+This policy considers a "CA Owner" to be the organization or legal entity that is either:
+
+- represented in the subject DN of the CA certificate; or
+- in possession or control of the corresponding private key capable of issuing new certificates, if not the same organization or legal entity directly represented in the subject DN of the certificate.
+
 ## Table of Contents
-1. [General Provisions](policy#1-general-provisions)
-2. [Contact Information](policy#2-contact-information)
-3. [Root CA Certificates](policy#3-root-ca-certificates)
-4. [Subordinate CA Certificates](policy#4-subordinate-ca-certificates)
-5. [Policies, Audits, and Audit Practices](policy#5-policies-audits-and-practices) <br>
-5.1 [Audit Statement Content](policy#51-audit-statement-content) <br>
-5.2 [Audit Firm and Audit Team Qualifications](policy#52-audit-firm-and-audit-team-qualifications) <br>
-5.3 [Annual CCADB Self-Assessments](policy#53-annual-ccadb-self-assessments) <br>
-6. [Mailshots](policy#6-mailshots)
 
+1. [General Provisions](policy#1-general-provisions) <br>
+2. [Contact Information Disclosures](policy#2-contact-information-disclosures) <br>
+3. [Certificate Disclosures](policy#3-certificate-disclosures) <br>
+3.1 [Root CA Certificates](policy#31-root-ca-certificates) <br>
+3.2 [Subordinate CA Certificates](policy#32-subordinate-ca-certificates) <br>
+4. [Policy Disclosures](policy#4-policy-disclosures) <br>
+5. [Audit Disclosures](policy#5-policy-disclosures) <br>
+5.1 [Scope of certificates covered by an Audit](policy#51-scope-of-certificates-covered-by-an-audit) <br>
+5.2 [Audit Statement Content](policy#52-audit-statement-content) <br>
+5.3 [Audit Firm and Audit Team Qualifications](policy#53-audit-firm-and-audit-team-qualifications) <br>
+6. [Additional Required Practices](policy#6-additional-required-practices) <br>
+6.1 [Disclosing and Responding to Incidents](policy#61-disclosing-and-responding-to-incidents) <br>
+6.2 [Certificate Revocation List Disclosures](policy#62-certificate-revocation-list-disclosures) <br>
+6.3 [Cross-certification across PKI Hierarchies](policy#63-cross-certification-across-pki-hierarchies) <br>
+6.4 [Annual CCADB Self-Assessments](policy#64-annual-ccadb-self-assessments) <br>
+7. [Mailshots](policy#7-mailshots) <br>
 
-## 1. General Provisions ##
+## 1. General Provisions
 
-Regardless of more specific provisions in these requirements, CA Owners have an overarching responsibility to keep the information in the CCADB about themselves, their operations and their certificates accurate, and to make updates in a timely fashion. Minimally, CA Owners with certificates included in a participating Store MUST ensure their information stored in the CCADB is kept up to date as changes occur.
+When required by a Root Store Operator policy, CA Owners MUST adhere to the current version of this policy. Failure to adhere to this policy MAY result in a Root Store Operator disabling a CA Owner’s root certificates, removing them from the corresponding Root Store, or the application of other technical or policy restrictions.
 
-All data in the CCADB may be made public or semi-public in a variety of forms; CA Owners SHOULD NOT place any information in the CCADB which they wish to keep confidential. Stores are not obliged to publish any CCADB information.
+Regardless of more specific provisions in these requirements, CA Owners have an overarching responsibility to keep the information in the CCADB about themselves, their operations and their certificates accurate, and to make updates in a timely fashion. Minimally, CA Owners with certificates included in a Root Store MUST ensure their information stored in the CCADB is kept up to date as changes occur. When a timeline is not defined for a requirement specified in this policy, updates MUST be submitted to the CCADB within 14 calendar days of an activity being completed.
+
+All CCADB disclosures MUST be made freely available and without additional requirements, including, but not limited to, registration, legal agreements, or restrictions on redistribution of the certificates in whole or in part.
+
+All data in the CCADB may be made public or semi-public in a variety of forms. CA Owners SHOULD NOT place any information in the CCADB which they wish to keep confidential. 
+
+Root Store Operators are not obliged to publish any CCADB information.
 
 All client devices that are used to download Personally Identifiable Information from the CCADB SHOULD employ disk-based encryption.
 
-## 2. Contact Information ##
+## 2. Contact Information Disclosures
 
 CA Owners MUST provide the following information for a Primary Point of Contact (POC), and at least one other POC, who MAY be a Primary POC:
 
 * Name
-* Office email address
+* CA Owner-affiliated email address
 
-CA Owners MAY optionally designate further POCs, supplying an email address for each. CA Owners MUST also supply at least one non-personal contact email aliases which are more likely to continue working as personnel change; these are maintained as part of the CA’s organizational entry.
+CA Owners MAY optionally designate further POCs, supplying an email address for each. CA Owners MUST also supply at least one non-personal contact email alias that is more likely to continue working as personnel change; these are maintained as part of the CA’s organizational entry.
 
 All Primary POCs SHOULD be authorized to speak for and enter into binding commitments on behalf of the CA(s) that they represent. The Primary POC will be issued a [CA Community license](https://www.ccadb.org/cas/request-access#application-for-ccadb-access) and MAY request additional licenses for other Primary POCs. Primary POCs are responsible for keeping CCADB data accurate for their CA(s).
 
-Notification of security and audit-related issues will be emailed to all Primary POCs and the first non-personal contact email alias. CA Owners are advised to make sure those addresses reach sufficient people such that they can respond to an issue in an appropriate timeframe.
+Notification of security and audit-related issues MAY be emailed to all individual POCs, non-personal contact email alias(es), or a combination of these addresses. CA Owners are advised to make sure those addresses reach sufficient people such that they can respond to an issue in an appropriate timeframe.
 
-If POC information needs to be updated, the CA Owner MUST submit an [Add/Update Contacts Case](https://www.ccadb.org/cas/contacts).
+CA Owners MUST maintain up to date contact details in the CCADB. If POC information needs to be updated, the CA Owner MUST submit an [Add/Update Contacts Case](https://www.ccadb.org/cas/contacts). A CA Owner's non-personal contact email alias(es) MUST be updated with an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates).
 
-## 3. Root CA Certificates ##
+## 3. Certificate Disclosures
 
-A root CA certificate is a self-signed certificate issued by the root CA to identify itself and to facilitate verification of certificates issued to its subordinate CAs. CA Owners are responsible for maintaining correct and current information about their root CA certificates.
+### 3.1 Root CA Certificates
 
-If root CA certificate information needs to be updated, the CA Owner MUST submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates).
+A root CA certificate is a self-signed certificate issued by the root CA to identify itself and to facilitate verification of certificates issued by its corresponding PKI hierarchy. 
 
-## 4. Subordinate CA Certificates ##
+CA Owners MUST maintain correct and current information about their root CA certificates. If root CA certificate information needs to be added or updated, the CA Owner MUST submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates).
 
-A subordinate CA certificate is a certificate signed by a root CA or another subordinate CA. The CCADB considers the terms "intermediate" and "subordinate" synonymous. To determine which subordinate CA certificates MUST be entered into the CCADB, refer to the individual Store policy. This includes certificates that are revoked. For newly-created subordinate CA certificates, this MUST happen before the certificate begins issuing publicly-trusted certificates.
+### 3.2 Subordinate CA Certificates
 
-Each instance (i.e. PEM data) of a subordinate CA certificate only needs to be included in the CCADB once.
+A subordinate CA certificate is a certificate signed by a root CA or another subordinate CA. The CCADB considers the terms "intermediate" and "subordinate" synonymous. 
 
-If a subordinate CA certificate is revoked, the CCADB MUST be updated to mark it as revoked, including the reason for revocation, within seven calendar days of revocation. 
+CA Owners MUST disclose:
+- all subordinate CA certificates capable of validating to a certificate included in a Root Store or associated with a CCADB Root Inclusion Request. Disclosure MUST take place within 7 calendar days of issuance and before the subject CA represented in the certificate begins issuing publicly-trusted certificates.
+- revocation of all subordinate CA certificates capable of validating to a certificate included in a Root Store or associated with a CCADB Root Inclusion Request within 7 calendar days of revocation.
 
-## 5. Policies, Audits, and Practices ##
+CA certificates created by cross-signing are considered subordinate CA certificates by Root Store Operators and MUST be disclosed to both the issuer and subject CA Owner PKI hierarchies in the CCADB. 
 
-CCADB enables associating Certificate Policy (CP) and/or Certification Practice Statement (CPS) documents in the records for both root CA certificates and subordinate CA certificates. CA Owners MUST provide at least an authoritative English version of any CP, CPS, or combined CP/CPS which are not originally in English, with version numbers matching the document they are a translation of.
+For any revoked subordinate CA certificate, each corresponding revocation entry published to a CRL MUST include a reasonCode extension. If the revocation is due to a security concern, the CA Owner MUST file a secure (i.e., "confidential") [Incident Report](https://www.ccadb.org/cas/incident-report#how-do-i-submit-a-security-sensitive-incident-report) in Bugzilla, with the expectation that a public Incident Report will eventually be filed.
 
-CCADB also enables associating statements of attestation of CA Owner conformance to various requirements and other operational criteria ("audits").
+## 4. Policy Disclosures
 
-These documents are hosted elsewhere and the URLs are stored in the CCADB. The URLs to such CP, CPS, CP/CPS, and audits, and any metadata about them such as the name of the auditor or the date of the audit, MUST be updated as new information becomes available. For technical reasons, URLs to audit statements MUST point to a PDF file that conforms to Audit Letter Validation (ALV) and either WebTrust or Accredited Conformity Assessment Bodies’ Council (ACAB'c) formatting standards.
+CCADB enables associating PKI policy documents in the records for both root CA certificates and subordinate CA certificates.
 
-The entry for each subordinate CA certificate has checkboxes to indicate "Audits Same as Parent", "CP Same as Parent", "CPS Same as Parent", and "CP/CPS Same as Parent". When those are checked, the details do not need to be duplicated from the parent certificate. However, the subordinate CA certificate MUST be specifically listed in the audit statements of the parent certificate.
+CA Owners with either (1) a certificate included in a Root Store or (2) a CA certificate that validates to a certificate included in a Root Store MUST minimally:
 
-URLs for the following documents are required for each certificate, unless the exceptions below apply:
+- accurately describe the policies and practices of their CA(s) within a Certificate Policy (CP) and corresponding Certification Practice Statement (CPS), or preferably, a single document combined as a CP/CPS.
+- ensure the CA policy documents are:
+    - freely publicly available for examination.
+    - available in an authoritative English language version.
+    - sufficiently detailed to assess the operations of the CA(s) and the compliance with the expectations set forth in this Policy, the applicable CA/Browser Forum Baseline Requirements, and any applicable Root Store Operator policies, and MUST NOT conflict with any of the requirements specified therein.
 
-* CP
-* CPS
-* Standard audit (WebTrust or ETSI)
-* Baseline Requirements (BR) audit (if the certificate is capable of issuing TLS/SSL server certificates)
-* Extended Validation (EV) SSL and/or Code Signing audit (if applicable)
+To promote simplicity and clarity, all CA policy documents SHOULD be:
+- focused on one specific PKI use case (e.g., TLS server authentication, TLS client authentication, S/MIME, Code Signing, etc.), rather than combining multiple use cases into a single document or set of documents.
+- comprehensive and consolidated, whenever possible, such that there are not multiple sets of similar yet slightly different policy and practice statements supporting the same PKI use case.
+- available in Markdown or AsciiDoc.
 
-Exceptions to providing these documents:
+CA Owners MUST strictly adhere to their policy document(s) as disclosed within the CCADB (and not marked as “Superseded”). This extends to all policy documents the CA Owner publishes in relation to its CAs included in a Root Store, such as TSPS documents.
+
+Before corresponding policy changes are put into practice, CA Owners:
+- MUST minimally ensure the updated versions of a CA's policy document(s) are uploaded to their own publicly accessible repository, and
+- SHOULD ensure the updated versions of a CA's policy document(s) are submitted to the CCADB within 7 calendar days of the policy document's effective date, but MUST do so within 14 calendar days.
+
+CA Owners MUST:
+- submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates) to add or update policy documents for root CA certificates stored in the CCADB.
+- add or update  policy documents for subordinate CA certificates directly on the record in CCADB (unless the exceptions stated below apply).
+
+Unless the exceptions below apply, CA policy disclosures for each certificate disclosed to the CCADB MUST be consistent with the following guidance:
+
+If the parent certificate record discloses a CP:
+- A) It MUST disclose a CPS
+- B) It MUST NOT disclose a CP/CPS
+- C) All child certificate records MUST either:
+     - (1) disclose a combined CP/CPS; or
+     - (2) disclose (a) a CP (either select "Same as Parent" checkbox or a different CP) and (b) a CPS (either select "Same as Parent" checkbox or a different CPS).
+
+If the parent certificate record discloses a CPS:
+- A) It MUST disclose a CP
+- B) It MUST NOT disclose a CP/CPS
+- C) All child certificate records MUST either:
+     - (1) disclose a combined CP/CPS; or
+     - (2) disclose (a) a CPS (either select "Same as Parent" checkbox or a different CPS) and (b) a CP (either select "Same as Parent" checkbox or a different CP).
+
+If the parent certificate record discloses a combined CP/CPS:
+- A) It MUST NOT disclose a CP
+- B) It MUST NOT disclose a CPS
+- C) All child certificate records MUST either:
+     - (1) disclose the same combined CP/CPS (using the "Same as Parent" checkbox);
+     - (2) disclose a different CP/CPS; or
+     - (3) disclose a CP and a CPS.
+
+Exceptions to providing these policy document URLs:
+
+- The certificate has expired; or
+- The certificate has been revoked, and the corresponding record in the CCADB has been updated with the correct revocation status.
+
+## 5. Audit Disclosures
+
+Beyond policy disclosures, CCADB also enables associating statements of attestation of CA Owner conformance to various requirements and other operational criteria ("audits").
+
+The URLs to such audit statements and any metadata about them such as the name of the auditor or the date of the audit MUST be updated as new information becomes available. For technical reasons, URLs to audit statements MUST point to a PDF file that conforms to Audit Letter Validation (ALV) and either WebTrust or Accredited Conformity Assessment Bodies’ Council (ACAB'c) formatting standards.
+
+The entry for each subordinate CA certificate has checkboxes to indicate "Audits Same as Parent". When the checkbox is checked, the details do not need to be duplicated from the parent certificate. However, the subordinate CA certificate MUST be specifically listed in the audit statements of the parent certificate.
+
+URLs for the following audit statements are required for each CA certificate, depending upon the purposes for which the certificate and those it issues are trusted. 
+
+| Trust Purpose | Description | Audits Required |  
+|---|---|---|
+| Server Authentication  | Any certificate issued by the CA (directly or transitively) contains an EKU value of: <br><br> (1) either 1.3.6.1.5.5.7.3.1 (id-kp-serverAuth) or 1.3.6.1.5.5.7.3.0 (anyExtendedKeyUsage), or <br><br> (2) No EKU | (1) Standard Audit <br><br> (2) NetSec Audit <br><br> (3) TLS BR Audit <br><br> (4) TLS EVG Audit (_only if issuing certificates that contain the CA/Browser Forum EV Certificate Policy Identifier (2.23.140.1.1)_) |
+| Client Authentication | Any certificate issued by the CA (directly or transitively) contains an EKU value of: <br><br> (1) either 1.3.6.1.5.5.7.3.2 (id-kp-clientAuth) or 1.3.6.1.5.5.7.3.0 (anyExtendedKeyUsage), or <br><br> (2) No EKU  | (1) Standard Audit <br><br> (2) NetSec Audit <br><br> (3) TLS BR Audit <br><br> (4) TLS EVG Audit (_only if issuing certificates that contain the CA/Browser Forum EV Certificate Policy Identifier (2.23.140.1.1)_) |
+| Code Signing           | Any certificate issued by the CA (directly or transitively) contains an EKU value of: <br><br>(1) either 1.3.6.1.5.5.7.3.3 (id-kp-codeSigning) or 1.3.6.1.5.5.7.3.0 (anyExtendedKeyUsage), or <br><br> (2) No EKU    | (1) Standard Audit <br><br> (2) NetSec Audit <br><br> (3) Code Signing Audit   |
+| Secure Email           | Any certificate issued by the CA (directly or transitively) contains an EKU value of: <br><br>(1) either 1.3.6.1.5.5.7.3.4 (id-kp-emailProtection) or 1.3.6.1.5.5.7.3.0 (anyExtendedKeyUsage), or <br><br> (2) No EKU   | (1) Standard Audit <br><br> (2) NetSec Audit <br><br> (3) S/MIME BR Audit  |
+
+Some Root Store Operators require additional audit disclosures to the CCADB.
+
+Exceptions to providing these audit statement URLs:
 
 * The SHA-256 fingerprint of the certificate is specifically listed as in scope in the audit statements of the parent certificate, and the "Audits Same as Parent" checkbox is checked; or
-* The certificate is issued and managed under the same CP, CPS, or CP/CPS as the parent certificate and the "CP Same as Parent", "CPS Same as Parent", and/or "CP/CPS Same as Parent" checkbox is checked; or
 * The certificate has expired; or
-* The certificate has been revoked, and the corresponding record in the CCADB has been updated with the correct revocation status.
+* The certificate has been revoked, and the corresponding record in the CCADB has been updated with the correct revocation status; or
+* The certificate was issued after the audit period of the most recently performed audit. In such cases, the certificate MUST be included in the scope of the CA Owner's next periodic audit.
 
-CA Owners MUST submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates) to add or update these documents for root CA certificates stored in the CCADB.
+CA Owners MUST:
+- submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates) to add or update audit statements for root CA certificates stored in the CCADB.
+- add or update audit statements for subordinate CA certificates directly on the record in the CCADB (unless the exceptions stated above apply).
 
-CA Owners MUST add or update these documents for subordinate CA certificates directly on the record in CCADB (unless the exceptions stated above apply).
+If an audit or audit statement disclosed to the CCADB does not meet the requirements of this policy, then a Root Store Operator MAY require that the CA Owner obtain a new audit, at the CA Owner's expense, for the period of time in question. Additionally, depending on the nature of concerns with the audit, a Root Store Operator MAY require that the CA Owner obtain such an audit from a new auditor.
 
-### 5.1 Audit Statement Content ###
+The presence of qualifications in an audit statement is not, by itself, generally considered a reason to remove a CA Owner from a Root Store. The purpose of audits is to honestly and thoroughly assess a CA Owner’s compliance with requirements which are necessary to assure a secure and stable ecosystem. Audit findings, including qualifications, can help to identify opportunities for improvement, whether for individual CAR Owners or for the wider industry as a whole.
 
-An authoritative English language version of publicly available audit information MUST be uploaded to the CCADB no later than three months after the end of the audit period. In the event of a delay greater than three months, the CA Owner MUST provide an explanatory letter signed by the Qualified Auditor. 
+### 5.1 Scope of Certificates Covered by an Audit
+
+CA certificates MUST appear in the Issuer’s annual audit statement, beginning with the statement corresponding to the audit period when the certificate was issued. Those certificates MUST continue to appear in audit statements until having appeared on at least one audit statement following revocation or key destruction (observed and reported by a Qualified Auditor).
+Self-signed certificates that share a Subject + SPKI with a root certificate that is, or was, included in a Root Store are treated by Root Store Operators as subordinate CA certificates because they chain up to an included root, so these certificates MUST also be listed in the applicable audit statements according to the [Derived Trust Bits](https://www.ccadb.org/cas/fields#formula-fields) field.
+CA certificates created by cross-signing are also considered subordinate CA certificates by Root Store Operators and MUST be included in all relevant audit statements of the entity that possesses the private key that performed the cross-signing.
+
+Cross-certificates issued before June 15, 2025 that DO NOT contain an EKU MUST appear in all of the Issuer’s annual audit statements for its corresponding Trust Purposes ([described above](policy#5-policy-disclosures)).
+
+### 5.2 Audit Statement Content
+
+An authoritative English language version of publicly available audit information MUST be uploaded to the CCADB no later than 92 calendar days from the point-in-time date or the end date of the period of time. In the event of a delay greater than 92 calendar days, the CA Owner MUST provide an explanatory letter signed by the Qualified Auditor. The CCADB warns Root Store Operators when the audit periods are not consecutive.
 
 Reports uploaded to the CCADB MUST be publicly available and contain at least the following clearly-labeled text-searchable information: 
 
 1. Full name of the CA Owner or corresponding Affiliate (e.g., organization providing external RA services) that was audited;
 2. Name and address of the organization performing the audit;
 3. Qualifications of the team performing the audit;
-4. SHA-256 fingerprint of each root and subordinate CA certificate that was in scope of the audit (see format specifications below);
-5. Full names and version numbers of the audit standards that were used during the audit;
-6. List of the CA Owner's applicable policy documents (with version numbers and publication dates) referenced during the audit;
-7. Whether the audit is for a period of time or a point in time;
-8. Start date and end date of the period that was audited, for those that cover a period of time (this is not the period the auditor was on-site);
-9. Point-in-time date, for those that are for a point in time;
-10. Date the audit statement was written, which will necessarily be after the audit period end date or point-in-time date (see date format specifications below);
-11. For ETSI, a statement to indicate if the audit was a full audit, and which parts of the criteria were applied, e.g. DVCP, OVCP, NCP, NCP+, LCP, EVCP, EVCP+, QCP-w, Part1 (General Requirements), and/or Part 2 (Requirements for trust service providers), and a statement to indicate that the auditor referenced the applicable CA/Browser Forum criteria and the version used;
-12. All incidents disclosed by the CA Owner, or reported by a third party, and all findings reported by an auditor, that, at any time during the audit period, occurred, were open in Bugzilla, or were reported to a Store; and
-13. An explicit statement indicating the audit covers the relevant systems and processes used in the issuance of all Certificates that assert one or more of the policy identifiers listed below:
+4. The physical locations that were and were not audited;
+5. SHA-256 fingerprint of each root and subordinate CA certificate that was in scope of the audit (see format specifications below);
+6. Full names and version numbers of the audit standards that were used during the audit;
+7. List of the CA Owner's applicable policy documents (with version numbers and publication dates) referenced during the audit;
+8. Whether the audit is for a period of time or a point in time;
+9. Start date and end date of the period that was audited, for those that cover a period of time (this is not the period the auditor was on-site);
+10. Point-in-time date, for those that are for a point in time;
+11. Date the audit statement was issued (referred to as the "issuing date" by the ACAB'c Audit Attestation Letter templates and "report date" by the WebTrust Illustrative Reports);
+    - For revised or corrected versions of audit statements made to address errors, omissions, or formatting to a previously completed audit statement, the CA Owner may enter the date of the initial issuance, provided that the scope and audit period covered by the revised audit statement remain unchanged. In such cases, the audit statement should contain the initial issuance date and the subsequent issuance date and the CA Owner should provide the URL of the most recent version and include a comment in the case explaining the revision date and the reason for reissuance of the audit statement.
+12. For ETSI, a statement to indicate if the audit was a full audit, and which parts of the criteria were applied, e.g. DVCP, OVCP, NCP, NCP+, LCP, EVCP, EVCP+, QCP-w, Part1 (General Requirements), and/or Part 2 (Requirements for trust service providers), and a statement to indicate that the auditor referenced the applicable CA/Browser Forum criteria and the version used;
+13. All incidents disclosed by the CA Owner, or reported by a third party, and all findings reported by an auditor, that, at any time during the audit period, occurred, were open in Bugzilla, or were reported to a Root Store Operator; and
+14. An explicit statement indicating the audit covers the relevant systems and processes used in the issuance of all certificates that assert one or more of the policy identifiers listed below:
 
 For hierarchies used to issue TLS certificates:
 - 2.23.140.1.2.1
@@ -154,27 +253,21 @@ For hierarchies used to issue S/MIME certificates:
 - 2.23.140.1.5.4.2
 - 2.23.140.1.5.4.3
 
-#### 5.1.1 ETSI ####
+#### 5.2.1 ETSI
 
 Audits conducted by an accredited Conformity Assessment Body (CAB) MUST have their Audit Attestation Letter (AAL) uploaded to the CAB’s website. CA Owners provide the URL to the AAL on the CAB’s website, and ALV will verify those URLs against a list of approved CAB websites. ETSI AALs MUST follow the latest version of the AAL template on the ACAB'c [website](https://www.acab-c.com/downloads/).
 
-CCADB warns root store operators when the audit periods are not consecutive.
-
 When the AAL cannot be posted on the CAB's website, the CA Owner MAY post the AAL on their own website or attach the attestation report to a [Bugzilla Bug](https://www.ccadb.org/cas/fields#uploading-documents) and provide that URL. The authenticity of the AAL will still need to be established by the CAB. 
 
-Additionally, if required by the individual Store policy, any non-conformity and/or problem resulting in the failure of the ETSI Certificate’s issuance MAY be considered an incident and have an [Audit Incident Report](https://www.ccadb.org/cas/incident-report) created in a Bugzilla Bug prior to or within seven calendar days of the AAL’s issuance date.
-
-#### 5.1.2 WebTrust ####
+#### 5.2.2 WebTrust
 
 Unqualified WebTrust audit statements provided by licensed WebTrust practitioners MUST have a WebTrust Seal. Qualified WebTrust audit statements provided by licensed WebTrust practitioners SHOULD have a WebTrust Seal. Whether unqualified or qualified, CAs enter the URL of the WebTrust Seal into the CCADB, and upon saving the record, the CCADB automatically converts the URL to point to the corresponding PDF file via integration with CPA Canada.
 
 For qualified WebTrust audits, if a Seal is not obtained from CPA Canada, then the CA Owner MUST post the audit statement on their own website or attach the audit statement to a [Bugzilla Bug](https://www.ccadb.org/cas/fields#uploading-documents) and provide that URL. The authenticity of any WebTrust audit statement not provided with a Seal from CPA Canada will still need to be established with the auditor.
 
-Additionally, if required by the individual Store policy, any qualification and/or modified opinion MAY be considered an incident and have an [Audit Incident Report](https://www.ccadb.org/cas/incident-report) created in a Bugzilla Bug prior to or within seven calendar days of the audit statement’s issuance date. 
+#### 5.2.3 ALV Formatting
 
-#### 5.1.3 ALV Formatting ####
-
-CCADB uses an application called Audit Letter Validation to automatically parse and validate audit statements. This system eliminates manual processing, but it requires audit statements to follow some basic rules in order to function properly. If the audit statement fails to meet any of the following requirements, the CA Owner MUST work with their auditor to provide an audit statement that passes ALV.
+The CCADB uses an application called Audit Letter Validation to automatically parse and validate audit statements. This system eliminates manual processing, but it requires audit statements to follow some basic rules in order to function properly. If the audit statement fails to meet any of the following requirements, the CA Owner MUST work with their auditor to provide an audit statement that passes ALV.
 
 Format Specifications for SHA-256 Fingerprints:
 
@@ -194,7 +287,8 @@ ALV supports the following format for specifying audit period date ranges:
 
 <br>
 ```<date><space><splitter><space><date>```
-<br>
+<br><br>
+    
 Where splitter MUST be one of the following:
 * to
 * through
@@ -203,11 +297,11 @@ Where splitter MUST be one of the following:
 * \-
 * \~
 
-### 5.2 Audit Firm and Audit Team Qualifications ###
+### 5.3 Audit Firm and Audit Team Qualifications
 
 CA Owners MUST ensure audits used to comply with this policy are performed by entities licensed or otherwise permitted to provide assurance services in the country(ies) where the assessment is performed, for the entirety of the audit engagement’s duration.
 
-#### 5.2.1 Audit Team Qualifications ####
+#### 5.3.1 Audit Team Qualifications
 
 Each audit statement MUST be accompanied by documentation of the audit team qualifications sufficient to determine the competence, experience, and independence of the auditor. This documentation MAY be part of the audit statement, or MAY be provided as a separate text-searchable PDF file, and MUST contain the following information:
 
@@ -226,24 +320,63 @@ Each audit statement MUST be accompanied by documentation of the audit team qual
 * How the audit team and team members are bound by law, regulation or professional standards to render an independent assessment of the CA (e.g., https://pub.aicpa.org/codeofconduct/Ethics.aspx# 0.300.050 Objectivity and Independence; CPA Canada, Rule 204; or Annex A of ETSI EN 319 403/403-1, respectively); and
 * Whether the audit team relied on any third-party specialists or affiliate audit firms, and if so, their names and where they performed services.
 
-### 5.3 Annual CCADB Self-Assessments ###
+## 6. Additional Required Practices
 
-Some Store policies MAY require the completion of an annual [self-assessment](https://www.ccadb.org/cas/self-assessment) using the CCADB template at various times to evaluate the conformance of the CA Owner’s policies against industry policies and practices.
+### 6.1 Disclosing and Responding to Incidents
 
-If an annual CCADB self-assessment is required by the individual Store policy, a single self-assessment MAY cover multiple CAs operating under both the same CP and CPS(s), or combined CP/CPS. CAs not operated under the same CP and CPS(s) or combined CP/CPS MUST be covered in a separate self-assessment.
+The CCADB [Incident Reporting Guidelines (IRGs)](https://www.ccadb.org/cas/incident-report) intend to present a common format for publicly disclosing incidents. CA Owners who are required to publicly disclose incidents MUST adhere to the CCADB IRGs. Those CA Owners MUST update the incidents and respond to questions in accordance with the IRGs until closure.
 
-The self-assessment submission date is determined by the earliest appearing "BR Audit Period End Date" field specified in any of the CA Owner’s "CA Owner/Certificate" CCADB root records that are included in one or more Stores. 
+### 6.2 Certificate Revocation List Disclosures
 
-An annual self-assessment MUST be completed and submitted to the CCADB within 92 calendar days from the CA Owner's earliest appearing root record "BR Audit Period End Date" that is after December 31, 2023. CA Owners SHOULD submit the self-assessment to the CCADB at the same time as uploading audit reports.
+For each unexpired and unrevoked CA certificate record disclosed to the CCADB and within 7 days of the corresponding CA issuing its first certificate, CA Owners MUST disclose either:
+- the URL of a full and complete Certificate Revocation List (CRL); or
+- a JSON Array of Partitioned CRL URLs.
 
-CA Owners SHOULD always use the latest available version of the self-assessment template. CA Owners MUST NOT use a version of the self-assessment template that has been superseded by more than 90 calendar days before their submission.
+URLs:
+- MUST match exactly as they appear in the certificates issued by the corresponding CA.
 
-## 6. Mailshots ##
+If populating a full and complete CRL URL: 
+- the corresponding CRL SHOULD NOT contain an 'Issuing Distribution Point' extension.
+- the JSON Array of Partitioned CRL URLs field MUST be empty.
 
-From time to time, a Store MAY use the CCADB to send information to CA Owners. Mailshots will be sent to at least the Primary POC(s) and the email aliases, and may also go to one or more of the other POCs; the exact recipient list is defined by the Store sending the information.
+If populating a JSON Array of Partitioned CRL URLs: 
+- CA Owners MUST ensure that each corresponding CRL contains a critical 'Issuing Distribution Point' extension and the 'distributionPoint' field of the extension MUST include a 'UniformResourceIdentifier'. The value of the UniformResourceIdentifier MUST exactly match a URL, from which the CRL was accessed, present in the CCADB record associated with the CA certificate.
+- the full and complete CRL URL MUST be empty.
+
+Under normal operating conditions, the CRL URLs provided by CAs in accordance with this section MUST be available such that relying parties are able to successfully retrieve the current CRL every 4 hours.
+
+### 6.3 Cross-certification across PKI Hierarchies
+
+Some Root Store Operators participating in the CCADB maintain policy requirements such that hierarchies included in the corresponding root store(s) are dedicated to a specific PKI use case, for example only supporting TLS server authentication. 
+
+In support of ubiquity use-cases, CA Owners sometimes issue cross-certificates from non-dedicated hierarchy Root CAs (i.e., “multi-purpose hierarchies”) to dedicated-use hierarchy Root CAs. 
+
+Beginning June 15, 2025, when new cross-certificates are issued across PKI hierarchies and the Subject CA’s public key (a) exists in or (b) might exist in a publicly-trusted self-signed Root CA certificate whose hierarchy should be considered dedicated to a specific PKI use case, the following EKU values MUST exist:
+
+| If the subject hierarchy is dedicated to… | EKU Presence? | EKU OID Permitted? |
+|---|---|---|
+| TLS server authentication | MUST | Only 1.3.6.1.5.5.7.3.1                       |
+| TLS client authentication | MUST | Only 1.3.6.1.5.5.7.3.2                       |
+| TLS (generic)             | MUST | Only 1.3.6.1.5.5.7.3.1 and 1.3.6.1.5.5.7.3.2 |
+| Code signing              | MUST | Only 1.3.6.1.5.5.7.3.3                       |
+| S/MIME                    | MUST | Only 1.3.6.1.5.5.7.3.4                       |
+
+In cases where both the Issuer and the Subject hierarchies are capable of issuing Extended Validation (EV) certificates, the cross-certificate MUST include the EV CA/Browser Forum Reserved Certificate Policy Identifier of 2.23.140.1.1 as a policyIdentifier. Additional policyIdentifiers MAY be present.
+
+### 6.4 Annual CCADB Self-Assessments
+
+At least annually, CA Owners MUST complete a self-assessment using [this](https://www.ccadb.org/cas/self-assessment) template to attest to the conformance of the CA Owner’s policies against industry policies and practices. CA Owners SHOULD always use the latest available version of the self-assessment template. CA Owners MUST NOT use a version of the self-assessment template that has been superseded by more than 90 calendar days before their submission.
+
+A single self-assessment MAY cover multiple CAs operating under both the same CP and CPS(s), or combined CP/CPS. CAs not operated under the same CP and CPS(s) or combined CP/CPS MUST be covered in a separate self-assessment.
+
+The self-assessment submission date is determined by the earliest appearing "BR Audit Period End Date" field specified in any of the CA Owner’s "CA Owner/Certificate" CCADB root records that are included in one or more Root Stores. 
+
+An annual self-assessment MUST be completed and submitted to the CCADB within 92 calendar days from the CA Owner's earliest appearing root record "BR Audit Period End Date." CA Owners SHOULD submit the self-assessment to the CCADB at the same time as uploading audit reports.
+
+## 7. Mailshots
+
+From time to time, a Root Store Operator MAY use the CCADB to send information to CA Owners. Mailshots will be sent to at least the Primary POC(s) and the CA Owners' email aliases, and may also go to one or more of the other POCs; the exact recipient list is defined by the Root Store Operator sending the information.
 
 -----
 
 Any copyright in this document is [dedicated to the Public Domain](https://creativecommons.org/publicdomain/zero/1.0/).
-
-[CCADB-Audit-Case]:    https://ccadb.org/cas/updates

--- a/policy.md
+++ b/policy.md
@@ -104,7 +104,9 @@ CA Owners MUST disclose:
 - all subordinate CA certificates capable of validating to a certificate included in a Root Store or associated with a CCADB Root Inclusion Request. Disclosure MUST take place within 7 calendar days of issuance and before the subject CA represented in the certificate begins issuing publicly-trusted certificates.
 - revocation of all subordinate CA certificates capable of validating to a certificate included in a Root Store or associated with a CCADB Root Inclusion Request within 7 calendar days of revocation.
 
-CA certificates created by cross-signing are considered subordinate CA certificates by Root Store Operators and MUST be disclosed to both the issuer and subject CA Owner PKI hierarchies in the CCADB. 
+Cross-certificates (i.e., where the same subject and public key of an existing CA certificate appears in at least one additional certificate issued by a _different_ CA Owner) are considered subordinate CA certificates by Root Store Operators and MUST be disclosed to the issuing CA Owner’s PKI hierarchy in the CCADB. 
+
+Ultimately, this means the subject CA certificate may appear in two distinct CA Owner PKI hierarchies, but it MUST minimally appear in the issuing CA Owner’s.
 
 For any revoked subordinate CA certificate, each corresponding revocation entry published to a CRL MUST include a reasonCode extension. If the revocation is due to a security concern, the CA Owner MUST file a secure (i.e., "confidential") [Incident Report](https://www.ccadb.org/cas/incident-report#how-do-i-submit-a-security-sensitive-incident-report) in Bugzilla, with the expectation that a public Incident Report will eventually be filed.
 

--- a/policy.md
+++ b/policy.md
@@ -1,6 +1,6 @@
 # CCADB Policy
 
-*Version 2.0, Effective: June 15, 2025*
+*Version 2.0, Effective: July 15, 2025*
 
 ## Introduction
 
@@ -14,7 +14,7 @@ Root Store Operators MAY have additional CCADB-related requirements defined in t
 
 |Version|Effective Date|
 |-|-|
-|2.0 (current)|June 15, 2025|
+|2.0 (current)|July 15, 2025|
 |[1.3.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_3_1.md)|October 29, 2024|
 |[1.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_3.md)|October 25, 2023|
 |[1.2.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_3.md)|July 19, 2023|
@@ -355,7 +355,7 @@ Beginning June 15, 2025, when new cross-certificates are issued across PKI hiera
 | TLS client authentication | MUST | Only 1.3.6.1.5.5.7.3.2                       |
 | TLS (generic)             | MUST | Only 1.3.6.1.5.5.7.3.1 and 1.3.6.1.5.5.7.3.2 |
 | S/MIME                    | MUST | Only 1.3.6.1.5.5.7.3.4                       |
-| S/MIME (generic)             | MUST | Only 1.3.6.1.5.5.7.3.4 and 1.3.6.1.5.5.7.3.2 |
+| S/MIME (generic)          | MUST | Only 1.3.6.1.5.5.7.3.4 and 1.3.6.1.5.5.7.3.2 |
 | Code signing              | MUST | Only 1.3.6.1.5.5.7.3.3                       |
 
 In cases where both the Issuer and the Subject hierarchies are capable of issuing Extended Validation (EV) certificates, the cross-certificate MUST include the EV CA/Browser Forum Reserved Certificate Policy Identifier of 2.23.140.1.1 as a policyIdentifier. Additional policyIdentifiers MAY be present.

--- a/policy.md
+++ b/policy.md
@@ -350,9 +350,9 @@ Beginning June 15, 2025, when new cross-certificates are issued across PKI hiera
 | TLS server authentication | MUST | Only 1.3.6.1.5.5.7.3.1                       |
 | TLS client authentication | MUST | Only 1.3.6.1.5.5.7.3.2                       |
 | TLS (generic)             | MUST | Only 1.3.6.1.5.5.7.3.1 and 1.3.6.1.5.5.7.3.2 |
+| S/MIME                    | MUST | Only 1.3.6.1.5.5.7.3.4                       |
 | S/MIME (generic)             | MUST | Only 1.3.6.1.5.5.7.3.4 and 1.3.6.1.5.5.7.3.2 |
 | Code signing              | MUST | Only 1.3.6.1.5.5.7.3.3                       |
-| S/MIME                    | MUST | Only 1.3.6.1.5.5.7.3.4                       |
 
 In cases where both the Issuer and the Subject hierarchies are capable of issuing Extended Validation (EV) certificates, the cross-certificate MUST include the EV CA/Browser Forum Reserved Certificate Policy Identifier of 2.23.140.1.1 as a policyIdentifier. Additional policyIdentifiers MAY be present.
 

--- a/policy.md
+++ b/policy.md
@@ -8,7 +8,7 @@ Several Public Root Store Operators have collaborated to create the Common Certi
 
 CA Owners who wish to be included in a CCADB-participating Root Store ("Root Store") need to disclose and maintain certain information in the CCADB. This policy describes common Root Store Operator requirements related to CA Owner use of the CCADB. This policy does not cover how to obtain write access to the CCADB or how to use the CCADB’s web interface. Additional information covering these topics is available [here](https://www.ccadb.org/cas/).
 
-Root Store Operators MAY have additional CCADB-related requirements defined in their own Root Store policies. These policies MAY strengthen the requirements described in this policy. Additional information on the policies belonging to the individual Root Store Operators participating in the CCADB can be found [here](https://www.ccadb.org/resources). Questions related to an individual Root Store Operator Policy SHOULD be directed to the operator of that policy using the contact address designated for that policy.
+Root Store Operators MAY have additional CCADB-related requirements defined in their own Root Store policies. Those policies MAY strengthen the requirements described in this policy. Additional information on the policies belonging to the individual Root Store Operators participating in the CCADB can be found [here](https://www.ccadb.org/resources). Questions related to an individual Root Store Operator Policy SHOULD be directed to the operator of that policy using the contact address designated for that policy.
 
 ## Change History
 

--- a/policy.md
+++ b/policy.md
@@ -318,7 +318,9 @@ Each audit statement MUST be accompanied by documentation of the audit team qual
 
 ### 6.1 Disclosing and Responding to Incidents
 
-The CCADB [Incident Reporting Guidelines (IRGs)](https://www.ccadb.org/cas/incident-report) intend to present a common format for publicly disclosing incidents. CA Owners who are required to publicly disclose incidents MUST adhere to the CCADB IRGs. Those CA Owners MUST update the incidents and respond to questions in accordance with the IRGs until closure.
+The CCADB [Incident Reporting Guidelines (IRGs)](https://www.ccadb.org/cas/incident-report) intend to present a common format for publicly disclosing incidents. CA Owners who are required to publicly disclose incidents:
+- SHOULD always use the latest available version of the CCADB IRG templates, and
+- MUST NOT use a version of an IRG template that has been superseded by more than 30 calendar days before the corresponding report (i.e., preliminary, full, or closure) is posted.
 
 ### 6.2 Certificate Revocation List Disclosures
 

--- a/policy.md
+++ b/policy.md
@@ -127,9 +127,8 @@ To promote simplicity and clarity, all CA policy documents SHOULD be:
 
 CA Owners MUST strictly adhere to their policy document(s) as disclosed within the CCADB (and not marked as “Superseded”). This extends to all policy documents the CA Owner publishes in relation to its CAs included in a Root Store, such as TSPS documents.
 
-Before corresponding policy changes are put into practice, CA Owners:
-- MUST minimally ensure the updated versions of a CA's policy document(s) are uploaded to their own publicly accessible repository, and
-- SHOULD ensure the updated versions of a CA's policy document(s) are submitted to the CCADB within 7 calendar days of the policy document's effective date, but MUST do so within 14 calendar days.
+CA Owners MUST ensure that updated versions of a CA's policy document(s) are uploaded to their own publicly accessible repository before the corresponding policy changes are put into practice. Corresponding policy changes are considered to be put into practice on the effective date specified in the policy document(s), unless individual requirements are explicitly future dated.
+Separately, CA Owners SHOULD ensure these updated policy document(s) are submitted to the CCADB within 7 calendar days of the policy document's effective date, and MUST ensure they are submitted within 14 calendar days of that effective date.
 
 CA Owners MUST:
 - submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates) to add or update policy documents for root CA certificates stored in the CCADB.

--- a/policy.md
+++ b/policy.md
@@ -192,7 +192,7 @@ The presence of qualifications in an audit statement is not, by itself, generall
 
 ### 5.1 Scope of Certificates Covered by an Audit
 
-CA certificates MUST appear in the Issuer’s annual audit statement, beginning with the statement corresponding to the audit period when the certificate was issued. Those certificates MUST continue to appear in audit statements until having appeared on at least one audit statement following revocation or key destruction (observed and reported by a Qualified Auditor).
+CA certificates MUST appear in the Issuer’s annual audit statement, beginning with the statement corresponding to the audit period when the certificate was issued. Those certificates MUST continue to appear in audit statements until having appeared on at least one audit statement following revocation, expiration, or key destruction (observed and reported by a Qualified Auditor).
 Self-signed certificates that share a Subject + SPKI with a root certificate that is, or was, included in a Root Store are treated by Root Store Operators as subordinate CA certificates because they chain up to an included root, so these certificates MUST also be listed in the applicable audit statements according to the [Derived Trust Bits](https://www.ccadb.org/cas/fields#formula-fields) field.
 CA certificates created by cross-signing are also considered subordinate CA certificates by Root Store Operators and MUST be included in all relevant audit statements of the entity that possesses the private key that performed the cross-signing.
 

--- a/policy.md
+++ b/policy.md
@@ -350,6 +350,7 @@ Beginning June 15, 2025, when new cross-certificates are issued across PKI hiera
 | TLS server authentication | MUST | Only 1.3.6.1.5.5.7.3.1                       |
 | TLS client authentication | MUST | Only 1.3.6.1.5.5.7.3.2                       |
 | TLS (generic)             | MUST | Only 1.3.6.1.5.5.7.3.1 and 1.3.6.1.5.5.7.3.2 |
+| S/MIME (generic)             | MUST | Only 1.3.6.1.5.5.7.3.4 and 1.3.6.1.5.5.7.3.2 |
 | Code signing              | MUST | Only 1.3.6.1.5.5.7.3.3                       |
 | S/MIME                    | MUST | Only 1.3.6.1.5.5.7.3.4                       |
 

--- a/policy.md
+++ b/policy.md
@@ -137,19 +137,12 @@ CA Owners MUST:
 
 Unless the exceptions below apply, CA policy disclosures for each certificate disclosed to the CCADB MUST be consistent with the following guidance:
 
-If the parent certificate record discloses a CP:
-- A) It MUST disclose a CPS
+If the parent certificate record discloses a CP or CPS:
+- A) It MUST disclose both a CP and a CPS
 - B) It MUST NOT disclose a CP/CPS
 - C) All child certificate records MUST either:
      - (1) disclose a combined CP/CPS; or
      - (2) disclose (a) a CP (either select "Same as Parent" checkbox or a different CP) and (b) a CPS (either select "Same as Parent" checkbox or a different CPS).
-
-If the parent certificate record discloses a CPS:
-- A) It MUST disclose a CP
-- B) It MUST NOT disclose a CP/CPS
-- C) All child certificate records MUST either:
-     - (1) disclose a combined CP/CPS; or
-     - (2) disclose (a) a CPS (either select "Same as Parent" checkbox or a different CPS) and (b) a CP (either select "Same as Parent" checkbox or a different CP).
 
 If the parent certificate record discloses a combined CP/CPS:
 - A) It MUST NOT disclose a CP

--- a/policy_archive/version_1_3_1.md
+++ b/policy_archive/version_1_3_1.md
@@ -1,0 +1,249 @@
+# CCADB Policy #
+
+*Version 1.3.1, Effective: October 29, 2024*
+
+## Introduction
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this policy are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+Several Web PKI root store operators ("Stores") have collaborated to create the Common Certification Authority Database (CCADB), a data repository of certificate and Certification Authority (CA) information. CA Owners who wish to be included in participating Stores will need to maintain certain information in the CCADB. This document explains what is required of CA Owners who are required by Store policy to use the CCADB.
+
+Stores MAY have their own additional CCADB-related requirements. For each root certificate, CA Owners MUST comply with the additional requirements pertaining to the Stores which contain that certificate. Additional information on Store requirements can be found [here](https://www.ccadb.org/resources).
+
+This policy does not cover how to obtain write access to the CCADB or how to use the CCADB’s web interface. Additional information covering these topics is available [here](https://www.ccadb.org/cas/).
+
+## Change History
+
+|Version|Effective Date|
+|-|-|
+|[1.0](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0.md)|May 23, 2017|
+|[1.0.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_1.md)|May 3, 2018|
+|[1.0.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_2.md)|May 3, 2018|
+|[1.0.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_3.md)|May 3, 2018|
+|[1.0.4](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_4.md)|July 16, 2018|
+|[1.0.5](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_0_5.md)|September 17, 2018|
+|[1.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_1.md)|December 6, 2021|
+|[1.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2.md)|February 15, 2023|
+|[1.2.1](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_1.md)|February 17, 2023|
+|[1.2.2](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_2.md)|May 11, 2023|
+|[1.2.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_2_3.md)|July 19, 2023|
+|[1.3](https://github.com/mozilla/www.ccadb.org/blob/master/policy_archive/version_1_3.md)|October 25, 2023|
+|1.3.1 (current)|October 29, 2024|
+
+<br>
+
+## Table of Contents
+1. [General Provisions](policy#1-general-provisions)
+2. [Contact Information](policy#2-contact-information)
+3. [Root CA Certificates](policy#3-root-ca-certificates)
+4. [Subordinate CA Certificates](policy#4-subordinate-ca-certificates)
+5. [Policies, Audits, and Audit Practices](policy#5-policies-audits-and-practices) <br>
+5.1 [Audit Statement Content](policy#51-audit-statement-content) <br>
+5.2 [Audit Firm and Audit Team Qualifications](policy#52-audit-firm-and-audit-team-qualifications) <br>
+5.3 [Annual CCADB Self-Assessments](policy#53-annual-ccadb-self-assessments) <br>
+6. [Mailshots](policy#6-mailshots)
+
+
+## 1. General Provisions ##
+
+Regardless of more specific provisions in these requirements, CA Owners have an overarching responsibility to keep the information in the CCADB about themselves, their operations and their certificates accurate, and to make updates in a timely fashion. Minimally, CA Owners with certificates included in a participating Store MUST ensure their information stored in the CCADB is kept up to date as changes occur.
+
+All data in the CCADB may be made public or semi-public in a variety of forms; CA Owners SHOULD NOT place any information in the CCADB which they wish to keep confidential. Stores are not obliged to publish any CCADB information.
+
+All client devices that are used to download Personally Identifiable Information from the CCADB SHOULD employ disk-based encryption.
+
+## 2. Contact Information ##
+
+CA Owners MUST provide the following information for a Primary Point of Contact (POC), and at least one other POC, who MAY be a Primary POC:
+
+* Name
+* Office email address
+
+CA Owners MAY optionally designate further POCs, supplying an email address for each. CA Owners MUST also supply at least one non-personal contact email aliases which are more likely to continue working as personnel change; these are maintained as part of the CA’s organizational entry.
+
+All Primary POCs SHOULD be authorized to speak for and enter into binding commitments on behalf of the CA(s) that they represent. The Primary POC will be issued a [CA Community license](https://www.ccadb.org/cas/request-access#application-for-ccadb-access) and MAY request additional licenses for other Primary POCs. Primary POCs are responsible for keeping CCADB data accurate for their CA(s).
+
+Notification of security and audit-related issues will be emailed to all Primary POCs and the first non-personal contact email alias. CA Owners are advised to make sure those addresses reach sufficient people such that they can respond to an issue in an appropriate timeframe.
+
+If POC information needs to be updated, the CA Owner MUST submit an [Add/Update Contacts Case](https://www.ccadb.org/cas/contacts).
+
+## 3. Root CA Certificates ##
+
+A root CA certificate is a self-signed certificate issued by the root CA to identify itself and to facilitate verification of certificates issued to its subordinate CAs. CA Owners are responsible for maintaining correct and current information about their root CA certificates.
+
+If root CA certificate information needs to be updated, the CA Owner MUST submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates).
+
+## 4. Subordinate CA Certificates ##
+
+A subordinate CA certificate is a certificate signed by a root CA or another subordinate CA. The CCADB considers the terms "intermediate" and "subordinate" synonymous. To determine which subordinate CA certificates MUST be entered into the CCADB, refer to the individual Store policy. This includes certificates that are revoked. For newly-created subordinate CA certificates, this MUST happen before the certificate begins issuing publicly-trusted certificates.
+
+Each instance (i.e. PEM data) of a subordinate CA certificate only needs to be included in the CCADB once.
+
+If a subordinate CA certificate is revoked, the CCADB MUST be updated to mark it as revoked, including the reason for revocation, within seven calendar days of revocation. 
+
+## 5. Policies, Audits, and Practices ##
+
+CCADB enables associating Certificate Policy (CP) and/or Certification Practice Statement (CPS) documents in the records for both root CA certificates and subordinate CA certificates. CA Owners MUST provide at least an authoritative English version of any CP, CPS, or combined CP/CPS which are not originally in English, with version numbers matching the document they are a translation of.
+
+CCADB also enables associating statements of attestation of CA Owner conformance to various requirements and other operational criteria ("audits").
+
+These documents are hosted elsewhere and the URLs are stored in the CCADB. The URLs to such CP, CPS, CP/CPS, and audits, and any metadata about them such as the name of the auditor or the date of the audit, MUST be updated as new information becomes available. For technical reasons, URLs to audit statements MUST point to a PDF file that conforms to Audit Letter Validation (ALV) and either WebTrust or Accredited Conformity Assessment Bodies’ Council (ACAB'c) formatting standards.
+
+The entry for each subordinate CA certificate has checkboxes to indicate "Audits Same as Parent", "CP Same as Parent", "CPS Same as Parent", and "CP/CPS Same as Parent". When those are checked, the details do not need to be duplicated from the parent certificate. However, the subordinate CA certificate MUST be specifically listed in the audit statements of the parent certificate.
+
+URLs for the following documents are required for each certificate, unless the exceptions below apply:
+
+* CP
+* CPS
+* Standard audit (WebTrust or ETSI)
+* Baseline Requirements (BR) audit (if the certificate is capable of issuing TLS/SSL server certificates)
+* Extended Validation (EV) SSL and/or Code Signing audit (if applicable)
+
+Exceptions to providing these documents:
+
+* The SHA-256 fingerprint of the certificate is specifically listed as in scope in the audit statements of the parent certificate, and the "Audits Same as Parent" checkbox is checked; or
+* The certificate is issued and managed under the same CP, CPS, or CP/CPS as the parent certificate and the "CP Same as Parent", "CPS Same as Parent", and/or "CP/CPS Same as Parent" checkbox is checked; or
+* The certificate has expired; or
+* The certificate has been revoked, and the corresponding record in the CCADB has been updated with the correct revocation status.
+
+CA Owners MUST submit an [Add/Update Root Request Case](https://www.ccadb.org/cas/updates) to add or update these documents for root CA certificates stored in the CCADB.
+
+CA Owners MUST add or update these documents for subordinate CA certificates directly on the record in CCADB (unless the exceptions stated above apply).
+
+### 5.1 Audit Statement Content ###
+
+An authoritative English language version of publicly available audit information MUST be uploaded to the CCADB no later than three months after the end of the audit period. In the event of a delay greater than three months, the CA Owner MUST provide an explanatory letter signed by the Qualified Auditor. 
+
+Reports uploaded to the CCADB MUST be publicly available and contain at least the following clearly-labeled text-searchable information: 
+
+1. Full name of the CA Owner or corresponding Affiliate (e.g., organization providing external RA services) that was audited;
+2. Name and address of the organization performing the audit;
+3. Qualifications of the team performing the audit;
+4. SHA-256 fingerprint of each root and subordinate CA certificate that was in scope of the audit (see format specifications below);
+5. Full names and version numbers of the audit standards that were used during the audit;
+6. List of the CA Owner's applicable policy documents (with version numbers and publication dates) referenced during the audit;
+7. Whether the audit is for a period of time or a point in time;
+8. Start date and end date of the period that was audited, for those that cover a period of time (this is not the period the auditor was on-site);
+9. Point-in-time date, for those that are for a point in time;
+10. Date the audit statement was written, which will necessarily be after the audit period end date or point-in-time date (see date format specifications below);
+11. For ETSI, a statement to indicate if the audit was a full audit, and which parts of the criteria were applied, e.g. DVCP, OVCP, NCP, NCP+, LCP, EVCP, EVCP+, QCP-w, Part1 (General Requirements), and/or Part 2 (Requirements for trust service providers), and a statement to indicate that the auditor referenced the applicable CA/Browser Forum criteria and the version used;
+12. All incidents disclosed by the CA Owner, or reported by a third party, and all findings reported by an auditor, that, at any time during the audit period, occurred, were open in Bugzilla, or were reported to a Store; and
+13. An explicit statement indicating the audit covers the relevant systems and processes used in the issuance of all Certificates that assert one or more of the policy identifiers listed below:
+
+For hierarchies used to issue TLS certificates:
+- 2.23.140.1.2.1
+- 2.23.140.1.2.2
+- 2.23.140.1.2.3
+- 2.23.140.1.1
+
+For hierarchies used to issue Code Signing certificates:
+- 2.23.140.1.4.1
+- 2.23.140.1.4.2
+- 2.23.140.1.3
+
+For hierarchies used to issue S/MIME certificates:
+- 2.23.140.1.5.1.1
+- 2.23.140.1.5.1.2
+- 2.23.140.1.5.1.3
+- 2.23.140.1.5.2.1
+- 2.23.140.1.5.2.2
+- 2.23.140.1.5.2.3
+- 2.23.140.1.5.3.1
+- 2.23.140.1.5.3.2
+- 2.23.140.1.5.3.3
+- 2.23.140.1.5.4.1
+- 2.23.140.1.5.4.2
+- 2.23.140.1.5.4.3
+
+#### 5.1.1 ETSI ####
+
+Audits conducted by an accredited Conformity Assessment Body (CAB) MUST have their Audit Attestation Letter (AAL) uploaded to the CAB’s website. CA Owners provide the URL to the AAL on the CAB’s website, and ALV will verify those URLs against a list of approved CAB websites. ETSI AALs MUST follow the latest version of the AAL template on the ACAB'c [website](https://www.acab-c.com/downloads/).
+
+CCADB warns root store operators when the audit periods are not consecutive.
+
+When the AAL cannot be posted on the CAB's website, the CA Owner MAY post the AAL on their own website or attach the attestation report to a [Bugzilla Bug](https://www.ccadb.org/cas/fields#uploading-documents) and provide that URL. The authenticity of the AAL will still need to be established by the CAB. 
+
+Additionally, if required by the individual Store policy, any non-conformity and/or problem resulting in the failure of the ETSI Certificate’s issuance MAY be considered an incident and have an [Audit Incident Report](https://www.ccadb.org/cas/incident-report) created in a Bugzilla Bug prior to or within seven calendar days of the AAL’s issuance date.
+
+#### 5.1.2 WebTrust ####
+
+Unqualified WebTrust audit statements provided by licensed WebTrust practitioners MUST have a WebTrust Seal. Qualified WebTrust audit statements provided by licensed WebTrust practitioners SHOULD have a WebTrust Seal. Whether unqualified or qualified, CAs enter the URL of the WebTrust Seal into the CCADB, and upon saving the record, the CCADB automatically converts the URL to point to the corresponding PDF file via integration with CPA Canada.
+
+For qualified WebTrust audits, if a Seal is not obtained from CPA Canada, then the CA Owner MUST post the audit statement on their own website or attach the audit statement to a [Bugzilla Bug](https://www.ccadb.org/cas/fields#uploading-documents) and provide that URL. The authenticity of any WebTrust audit statement not provided with a Seal from CPA Canada will still need to be established with the auditor.
+
+Additionally, if required by the individual Store policy, any qualification and/or modified opinion MAY be considered an incident and have an [Audit Incident Report](https://www.ccadb.org/cas/incident-report) created in a Bugzilla Bug prior to or within seven calendar days of the audit statement’s issuance date. 
+
+#### 5.1.3 ALV Formatting ####
+
+CCADB uses an application called Audit Letter Validation to automatically parse and validate audit statements. This system eliminates manual processing, but it requires audit statements to follow some basic rules in order to function properly. If the audit statement fails to meet any of the following requirements, the CA Owner MUST work with their auditor to provide an audit statement that passes ALV.
+
+Format Specifications for SHA-256 Fingerprints:
+
+* MUST: No colons, no spaces, and no line feeds
+* MUST: Uppercase letters
+* MUST: Be encoded in the document (PDF) as text searchable, not an image
+
+Format Specifications for Dates: The following formats are accepted by ALV:
+
+* Month DD, YYYY example: May 7, 2016
+* DD Month YYYY example: 7 May 2016
+* YYYY-MM-DD example: 2016-05-07
+* Month names in English
+* No extra text within the date, such as "7th" or "the"
+
+ALV supports the following format for specifying audit period date ranges:
+
+<br>
+```<date><space><splitter><space><date>```
+<br>
+Where splitter MUST be one of the following:
+* to
+* through
+* until
+* and
+* \-
+* \~
+
+### 5.2 Audit Firm and Audit Team Qualifications ###
+
+CA Owners MUST ensure audits used to comply with this policy are performed by entities licensed or otherwise permitted to provide assurance services in the country(ies) where the assessment is performed, for the entirety of the audit engagement’s duration.
+
+#### 5.2.1 Audit Team Qualifications ####
+
+Each audit statement MUST be accompanied by documentation of the audit team qualifications sufficient to determine the competence, experience, and independence of the auditor. This documentation MAY be part of the audit statement, or MAY be provided as a separate text-searchable PDF file, and MUST contain the following information:
+
+* Date that the audit report was signed;
+* Full name of the CA Owner that was audited;
+* Name and address of the audit firm or CAB;
+* Audit criteria (e.g., ETSI / WebTrust);
+* Proof of audit firm or CAB Accreditation URL (e.g., the auditor is listed in [CPA Canada's Licensed WebTrust practitioners web page](https://www.cpacanada.ca/en/business-and-accounting-resources/audit-and-assurance/overview-of-webtrust-services/licensed-webtrust-practitioners-international) or the CAB’s name and [Accreditation Attestation](https://european-accreditation.org/ea-%20members/directory-of-ea-members-and-mla-signatories/) are listed in the [ACAB'c CAB-member List](https://www.acab-c.com/members/));
+* Name of Lead Auditor or Signing Partner (except where prohibited by law or other public policy, in which case, we ask that you not provide any personally identifiable information in the document);
+* For the audit team and the audit Quality Reviewer or QA Partner, qualification information such as:
+    - Number of audit team members;
+    - Academic qualifications or professional training received;
+    - Average years of auditing experience auditing trust services or similar information systems;
+    - Experience, special skills, and qualifications (e.g., audit/assessment principles and functions, information technology, software development, trust services, public key infrastructure, CA operations, and information security including risk assessment/management, network security, physical security, etc.); and
+    - Credentials, designations, or certifications (e.g., CPA, CISA, CITP, CISSP, CCSP/CCA/CCP, etc.).
+* How the audit team and team members are bound by law, regulation or professional standards to render an independent assessment of the CA (e.g., https://pub.aicpa.org/codeofconduct/Ethics.aspx# 0.300.050 Objectivity and Independence; CPA Canada, Rule 204; or Annex A of ETSI EN 319 403/403-1, respectively); and
+* Whether the audit team relied on any third-party specialists or affiliate audit firms, and if so, their names and where they performed services.
+
+### 5.3 Annual CCADB Self-Assessments ###
+
+Some Store policies MAY require the completion of an annual [self-assessment](https://www.ccadb.org/cas/self-assessment) using the CCADB template at various times to evaluate the conformance of the CA Owner’s policies against industry policies and practices.
+
+If an annual CCADB self-assessment is required by the individual Store policy, a single self-assessment MAY cover multiple CAs operating under both the same CP and CPS(s), or combined CP/CPS. CAs not operated under the same CP and CPS(s) or combined CP/CPS MUST be covered in a separate self-assessment.
+
+The self-assessment submission date is determined by the earliest appearing "BR Audit Period End Date" field specified in any of the CA Owner’s "CA Owner/Certificate" CCADB root records that are included in one or more Stores. 
+
+An annual self-assessment MUST be completed and submitted to the CCADB within 92 calendar days from the CA Owner's earliest appearing root record "BR Audit Period End Date" that is after December 31, 2023. CA Owners SHOULD submit the self-assessment to the CCADB at the same time as uploading audit reports.
+
+CA Owners SHOULD always use the latest available version of the self-assessment template. CA Owners MUST NOT use a version of the self-assessment template that has been superseded by more than 90 calendar days before their submission.
+
+## 6. Mailshots ##
+
+From time to time, a Store MAY use the CCADB to send information to CA Owners. Mailshots will be sent to at least the Primary POC(s) and the email aliases, and may also go to one or more of the other POCs; the exact recipient list is defined by the Store sending the information.
+
+-----
+
+Any copyright in this document is [dedicated to the Public Domain](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[CCADB-Audit-Case]:    https://ccadb.org/cas/updates


### PR DESCRIPTION
Following the community’s recent [iteration](https://groups.google.com/a/ccadb.org/g/public/c/GIBHz9FUjHY/m/XOOLNpOFCAAJ) and improvement on the updated [CCADB Incident Reporting Guidelines](https://www.ccadb.org/cas/incident-report) (IRGs), the CCADB Steering Committee has collaborated on an updated draft of the CCADB Policy.

**Objectives for this update include:**

- Clarifying Root Store Operator expectations related to CCADB disclosures. Some of these clarifications were motivated by public incident reports filed to Bugzilla over the past year.
- Creating opportunities to (a) remove redundant/similar requirements located across root program policies related to CCADB disclosures and (b) promote future simplicity.
- Promoting simplicity and improving readability through a reorganization of normative and non-normative requirements.

Additionally, minor updates are proposed to the IRGs (e.g., further streamlining the incident closure process).

We'll soon solicit feedback on this draft using the public [at] ccadb [dot] or [discussion group](https://groups.google.com/a/ccadb.org/g/public/about).